### PR TITLE
Add weekly schedule management for warehouses

### DIFF
--- a/admin/assets/js/horarios.js
+++ b/admin/assets/js/horarios.js
@@ -1,0 +1,18 @@
+document.addEventListener('click', function(e){
+  if(e.target.classList.contains('add-block')){
+    var day = e.target.getAttribute('data-day');
+    var container = e.target.closest('.day-block').querySelector('.blocks');
+    var div = document.createElement('div');
+    div.className = 'block form-group row';
+    div.innerHTML = '<div class="col-sm-5"><input type="time" step="300" name="horarios['+day+'][inicio][]" class="form-control"></div>' +
+                    '<div class="col-sm-5"><input type="time" step="300" name="horarios['+day+'][fin][]" class="form-control"></div>' +
+                    '<div class="col-sm-2"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>';
+    container.appendChild(div);
+  }
+  if(e.target.classList.contains('remove-block')){
+    var block = e.target.closest('.block');
+    if(block){
+      block.remove();
+    }
+  }
+});

--- a/admin/modificarAlmacen.php
+++ b/admin/modificarAlmacen.php
@@ -4,6 +4,8 @@ if(empty($_SESSION['user']['id_perfil'])){
   header("Location: index.php");
   die("Redirecting to index.php"); 
 }
+$diasSemana = ['Lunes','Martes','Miércoles','Jueves','Viernes','Sábado','Domingo'];
+$horarios = [];
 require 'database.php';
 
 $id = null;
@@ -17,14 +19,35 @@ if ( null==$id ) {
 
 if ( !empty($_POST)) {
 
-  // insert data
+  // update data
   $pdo = Database::connect();
   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+  $pdo->beginTransaction();
 
   $sql = "UPDATE almacenes set almacen = ?, iniciales_codigo_productos = ?, direccion = ?, id_tipo = ?, punto_venta = ?, activo = ? where id = ?";
   $q = $pdo->prepare($sql);
   $q->execute(array($_POST['almacen'],$_POST['iniciales_codigo_productos'],$_POST['direccion'],$_POST['id_tipo'],$_POST['punto_venta'],$_POST['activo'],$_GET['id']));
 
+  $pdo->prepare("DELETE FROM almacenes_horarios WHERE id_almacen = ?")->execute(array($_GET['id']));
+
+  if (!empty($_POST['horarios'])) {
+    $sqlH = "INSERT INTO almacenes_horarios(id_almacen,dia_semana,hora_inicio,hora_fin,frecuencia_minutos,bloqueo_minutos) VALUES (?,?,?,?,?,?)";
+    $qH = $pdo->prepare($sqlH);
+    foreach ($_POST['horarios'] as $dia => $dataDia) {
+      $freq = $_POST['frecuencia_minutos'][$dia] ?? null;
+      $bloq = $_POST['bloqueo_minutos'][$dia] ?? null;
+      $inicios = $dataDia['inicio'] ?? [];
+      $fines   = $dataDia['fin'] ?? [];
+      foreach ($inicios as $k => $ini) {
+        $fin = $fines[$k] ?? null;
+        if ($ini && $fin) {
+          $qH->execute(array($_GET['id'],$dia,$ini,$fin,$freq,$bloq));
+        }
+      }
+    }
+  }
+
+  $pdo->commit();
   Database::disconnect();
 
   header("Location: listarAlmacenes.php");
@@ -37,6 +60,17 @@ if ( !empty($_POST)) {
   $q = $pdo->prepare($sql);
   $q->execute(array($id));
   $data = $q->fetch(PDO::FETCH_ASSOC);
+
+  $sqlH = "SELECT dia_semana,hora_inicio,hora_fin,frecuencia_minutos,bloqueo_minutos FROM almacenes_horarios WHERE id_almacen = ? ORDER BY dia_semana,hora_inicio";
+  $qH = $pdo->prepare($sqlH);
+  $qH->execute(array($id));
+  while($row = $qH->fetch(PDO::FETCH_ASSOC)){
+    $d = $row['dia_semana'];
+    $horarios[$d]['frecuencia_minutos'] = $row['frecuencia_minutos'];
+    $horarios[$d]['bloqueo_minutos'] = $row['bloqueo_minutos'];
+    $horarios[$d]['inicio'][] = $row['hora_inicio'];
+    $horarios[$d]['fin'][] = $row['hora_fin'];
+  }
 
   Database::disconnect();
 }
@@ -123,20 +157,52 @@ if ( !empty($_POST)) {
                             <label class="col-sm-3 col-form-label">Punto de venta Facturacion Electrónica</label>
                             <div class="col-sm-9"><input name="punto_venta" type="number" maxlength="99" class="form-control" value="<?=$data['punto_venta']; ?>"></div>
                           </div>
-                          <div class="form-group row">
-                            <label class="col-sm-3 col-form-label">Activo</label>
-                            <div class="col-sm-9">
-                              <select name="activo" id="activo" class="js-example-basic-single col-sm-12" required="required">
-                                <option value="">Seleccione...</option>
-                                <option value="1" <?php if ($data['activo']==1) echo " selected ";?>>Si</option>
-                                <option value="0" <?php if ($data['activo']==0) echo " selected ";?>>No</option>
-                              </select>
+                            <div class="form-group row">
+                              <label class="col-sm-3 col-form-label">Activo</label>
+                              <div class="col-sm-9">
+                                <select name="activo" id="activo" class="js-example-basic-single col-sm-12" required="required">
+                                  <option value="">Seleccione...</option>
+                                  <option value="1" <?php if ($data['activo']==1) echo " selected ";?>>Si</option>
+                                  <option value="0" <?php if ($data['activo']==0) echo " selected ";?>>No</option>
+                                </select>
+                              </div>
                             </div>
+
+<?php for($d=0;$d<7;$d++): 
+  $freq = $horarios[$d]['frecuencia_minutos'] ?? '';
+  $bloq = $horarios[$d]['bloqueo_minutos'] ?? '';
+?>
+  <div class="day-block mb-3 border p-3">
+    <h6><?= $diasSemana[$d] ?></h6>
+    <div class="form-group row">
+      <label class="col-sm-3 col-form-label">Frecuencia (min)</label>
+      <div class="col-sm-3"><input type="number" step="5" name="frecuencia_minutos[<?= $d ?>]" class="form-control" value="<?= $freq ?>"></div>
+      <label class="col-sm-3 col-form-label">Bloqueo (min)</label>
+      <div class="col-sm-3"><input type="number" name="bloqueo_minutos[<?= $d ?>]" class="form-control" value="<?= $bloq ?>"></div>
+    </div>
+    <div class="blocks">
+<?php if(!empty($horarios[$d]['inicio'])): foreach($horarios[$d]['inicio'] as $i=>$ini): $fin = $horarios[$d]['fin'][$i] ?? ''; ?>
+      <div class="block form-group row">
+        <div class="col-sm-5"><input type="time" step="300" name="horarios[<?= $d ?>][inicio][]" class="form-control" value="<?= $ini ?>"></div>
+        <div class="col-sm-5"><input type="time" step="300" name="horarios[<?= $d ?>][fin][]" class="form-control" value="<?= $fin ?>"></div>
+        <div class="col-sm-2"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>
+      </div>
+<?php endforeach; else: ?>
+      <div class="block form-group row">
+        <div class="col-sm-5"><input type="time" step="300" name="horarios[<?= $d ?>][inicio][]" class="form-control"></div>
+        <div class="col-sm-5"><input type="time" step="300" name="horarios[<?= $d ?>][fin][]" class="form-control"></div>
+        <div class="col-sm-2"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>
+      </div>
+<?php endif; ?>
+    </div>
+    <button type="button" class="btn btn-secondary btn-sm add-block" data-day="<?= $d ?>">Agregar bloque</button>
+  </div>
+<?php endfor; ?>
+
                           </div>
                         </div>
                       </div>
-                    </div>
-                    <div class="card-footer">
+                      <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
                         <button class="btn btn-primary" type="submit">Modificar</button>
 						            <a href='listarAlmacenes.php' class="btn btn-light">Volver</a>
@@ -175,13 +241,14 @@ if ( !empty($_POST)) {
     <!-- Plugins JS Ends-->
     <!-- Theme js-->
     <script src="assets/js/script.js"></script>
-    <!-- Plugin used-->
-	  <script src="assets/js/select2/select2.full.min.js"></script>
-    <script src="assets/js/select2/select2-custom.js"></script>
-    <script>
-      function convertirAMayusculas(input) {
-        input.value = input.value.toUpperCase();
-      }
-    </script>
+      <!-- Plugin used-->
+            <script src="assets/js/select2/select2.full.min.js"></script>
+      <script src="assets/js/select2/select2-custom.js"></script>
+      <script src="assets/js/horarios.js"></script>
+      <script>
+        function convertirAMayusculas(input) {
+          input.value = input.value.toUpperCase();
+        }
+      </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- extend warehouse forms with day-by-day schedule sections including time blocks, frequency, and blocking minutes
- add JS helpers to dynamically add or remove schedule blocks
- persist schedule data in `almacenes_horarios` when creating or editing warehouses

## Testing
- `php -l admin/nuevoAlmacen.php`
- `php -l admin/modificarAlmacen.php`
- `node --check admin/assets/js/horarios.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc5d60a9108321945d2b1138bdd19f