### PR TITLE
Validate horarios input for almacenes

### DIFF
--- a/admin/modificarAlmacen.php
+++ b/admin/modificarAlmacen.php
@@ -19,6 +19,33 @@ if ( null==$id ) {
 
 if ( !empty($_POST)) {
 
+  // Validaciones de horarios
+  $errores = [];
+  if (!empty($_POST['horarios'])) {
+    foreach ($_POST['horarios'] as $dia => $dataDia) {
+      $freq = isset($_POST['frecuencia_minutos'][$dia]) ? (int)$_POST['frecuencia_minutos'][$dia] : 0;
+      $bloq = isset($_POST['bloqueo_minutos'][$dia]) ? (int)$_POST['bloqueo_minutos'][$dia] : 0;
+      if ($freq <= 0 || $freq % 5 !== 0) {
+        $errores[] = 'Frecuencia inválida para el día ' . $diasSemana[$dia];
+      }
+      if ($bloq < $freq) {
+        $errores[] = 'Bloqueo inválido para el día ' . $diasSemana[$dia];
+      }
+      $inicios = $dataDia['inicio'] ?? [];
+      $fines   = $dataDia['fin'] ?? [];
+      foreach ($inicios as $k => $ini) {
+        $fin = $fines[$k] ?? null;
+        if ($ini && $fin && $ini >= $fin) {
+          $errores[] = 'Hora inicio debe ser menor a hora fin para el día ' . $diasSemana[$dia];
+        }
+      }
+    }
+  }
+  if ($errores) {
+    echo implode('<br>', $errores);
+    exit;
+  }
+
   // update data
   $pdo = Database::connect();
   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/admin/nuevoAlmacen.php
+++ b/admin/nuevoAlmacen.php
@@ -11,6 +11,33 @@ $horarios = [];
 
 if ( !empty($_POST)) {
 
+  // Validaciones de horarios
+  $errores = [];
+  if (!empty($_POST['horarios'])) {
+    foreach ($_POST['horarios'] as $dia => $dataDia) {
+      $freq = isset($_POST['frecuencia_minutos'][$dia]) ? (int)$_POST['frecuencia_minutos'][$dia] : 0;
+      $bloq = isset($_POST['bloqueo_minutos'][$dia]) ? (int)$_POST['bloqueo_minutos'][$dia] : 0;
+      if ($freq <= 0 || $freq % 5 !== 0) {
+        $errores[] = 'Frecuencia inválida para el día ' . $diasSemana[$dia];
+      }
+      if ($bloq < $freq) {
+        $errores[] = 'Bloqueo inválido para el día ' . $diasSemana[$dia];
+      }
+      $inicios = $dataDia['inicio'] ?? [];
+      $fines   = $dataDia['fin'] ?? [];
+      foreach ($inicios as $k => $ini) {
+        $fin = $fines[$k] ?? null;
+        if ($ini && $fin && $ini >= $fin) {
+          $errores[] = 'Hora inicio debe ser menor a hora fin para el día ' . $diasSemana[$dia];
+        }
+      }
+    }
+  }
+  if ($errores) {
+    echo implode('<br>', $errores);
+    exit;
+  }
+
   // insert data
   $pdo = Database::connect();
   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);


### PR DESCRIPTION
## Summary
- validate frecuencia/bloqueo/minutos and time ranges when creating or updating almacenes

## Testing
- `php -l admin/nuevoAlmacen.php`
- `php -l admin/modificarAlmacen.php`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf67acbd883218bbddb326b1ee246