### PR TITLE
Add tooltip icons for schedule settings

### DIFF
--- a/admin/assets/js/tooltip-init.js
+++ b/admin/assets/js/tooltip-init.js
@@ -1,12 +1,16 @@
 (function($) {
-	"use strict";
-	var tooltip_init = {
-		init: function() {
-			$("button").tooltip();
-			$("a").tooltip();
-			$("input").tooltip();
-			$("img").tooltip();
-		}
-	};
-    tooltip_init.init()
+    "use strict";
+    var tooltip_init = {
+        init: function() {
+            $("button").tooltip();
+            $("a").tooltip();
+            $("input").tooltip();
+            $("img").tooltip();
+        }
+    };
+    tooltip_init.init();
+    $(function(){
+        $('[data-toggle="tooltip"]').tooltip();
+    });
 })(jQuery);
+

--- a/admin/modificarAlmacen.php
+++ b/admin/modificarAlmacen.php
@@ -203,9 +203,15 @@ if ( !empty($_POST)) {
 
   <h5 class="schedule-title">Configuración de horarios</h5>
   <div class="form-group row">
-    <label class="col-sm-3 col-form-label">Frecuencia (min)</label>
+    <label class="col-sm-3 col-form-label">
+      Frecuencia (min)
+      <i class="fa fa-info-circle ml-1" data-toggle="tooltip" data-placement="top" title="Intervalo entre turnos (múltiplos de 5 minutos)"></i>
+    </label>
     <div class="col-sm-3"><input type="number" step="5" name="frecuencia_minutos" class="form-control" value="<?= $freqGlobal ?>"></div>
-    <label class="col-sm-3 col-form-label">Bloqueo (min)</label>
+    <label class="col-sm-3 col-form-label">
+      Bloqueo (min)
+      <i class="fa fa-info-circle ml-1" data-toggle="tooltip" data-placement="top" title="Minutos adicionales bloqueados tras un turno reservado"></i>
+    </label>
     <div class="col-sm-3"><input type="number" name="bloqueo_minutos" class="form-control" value="<?= $bloqGlobal ?>"></div>
   </div>
   <?php for($d=0;$d<7;$d++): ?>

--- a/admin/nuevoAlmacen.php
+++ b/admin/nuevoAlmacen.php
@@ -157,9 +157,15 @@ if ( !empty($_POST)) {
                           </div>
                           <h5 class="schedule-title">Configuración de horarios</h5>
                           <div class="form-group row">
-                            <label class="col-sm-3 col-form-label">Frecuencia (min)</label>
+                            <label class="col-sm-3 col-form-label">
+                              Frecuencia (min)
+                              <i class="fa fa-info-circle ml-1" data-toggle="tooltip" data-placement="top" title="Intervalo entre turnos (múltiplos de 5 minutos)"></i>
+                            </label>
                             <div class="col-sm-3"><input type="number" step="5" name="frecuencia_minutos" class="form-control"></div>
-                            <label class="col-sm-3 col-form-label">Bloqueo (min)</label>
+                            <label class="col-sm-3 col-form-label">
+                              Bloqueo (min)
+                              <i class="fa fa-info-circle ml-1" data-toggle="tooltip" data-placement="top" title="Minutos adicionales bloqueados tras un turno reservado"></i>
+                            </label>
                             <div class="col-sm-3"><input type="number" name="bloqueo_minutos" class="form-control"></div>
                           </div>
 <?php for($d=0;$d<7;$d++): ?>


### PR DESCRIPTION
## Summary
- add info-circle icons with tooltips for Frecuencia and Bloqueo fields in almacén forms
- enable bootstrap tooltip initialization for data-toggle elements

## Testing
- `php -l admin/nuevoAlmacen.php`
- `php -l admin/modificarAlmacen.php`
- `node --check admin/assets/js/tooltip-init.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68be0c983aa88321bdc7d3eb8bc13503