### PR TITLE
Add schedule block labels and dynamic numbering

### DIFF
--- a/admin/assets/js/horarios.js
+++ b/admin/assets/js/horarios.js
@@ -1,18 +1,25 @@
 document.addEventListener('click', function(e){
-  if(e.target.classList.contains('add-block')){
+  if (e.target.classList.contains('add-block')) {
     var day = e.target.getAttribute('data-day');
     var container = e.target.closest('.day-block').querySelector('.blocks');
+    var count = container.querySelectorAll('.block').length + 1;
     var div = document.createElement('div');
     div.className = 'block form-group row';
-    div.innerHTML = '<div class="col-sm-5"><input type="time" step="300" name="horarios['+day+'][inicio][]" class="form-control"></div>' +
-                    '<div class="col-sm-5"><input type="time" step="300" name="horarios['+day+'][fin][]" class="form-control"></div>' +
-                    '<div class="col-sm-2"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>';
+    div.innerHTML =
+      '<span class="block-label col-12">Bloque ' + count + '</span>' +
+      '<div class="col-sm-5"><label>Inicio</label><input type="time" step="300" name="horarios[' + day + '][inicio][]" class="form-control"></div>' +
+      '<div class="col-sm-5"><label>Fin</label><input type="time" step="300" name="horarios[' + day + '][fin][]" class="form-control"></div>' +
+      '<div class="col-sm-2 d-flex align-items-end"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>';
     container.appendChild(div);
   }
-  if(e.target.classList.contains('remove-block')){
+  if (e.target.classList.contains('remove-block')) {
     var block = e.target.closest('.block');
-    if(block){
+    if (block) {
+      var container = block.parentElement;
       block.remove();
+      container.querySelectorAll('.block-label').forEach(function(label, idx){
+        label.textContent = 'Bloque ' + (idx + 1);
+      });
     }
   }
 });

--- a/admin/modificarAlmacen.php
+++ b/admin/modificarAlmacen.php
@@ -113,6 +113,9 @@ if ( !empty($_POST)) {
             margin-top: 1.5rem;
             margin-bottom: 1rem;
           }
+          .block-label {
+            font-weight: bold;
+          }
         </style>
   </head>
   <body class="light-only">
@@ -220,15 +223,29 @@ if ( !empty($_POST)) {
       <div class="blocks">
   <?php if(!empty($horarios[$d]['inicio'])): foreach($horarios[$d]['inicio'] as $i=>$ini): $fin = $horarios[$d]['fin'][$i] ?? ''; ?>
         <div class="block form-group row">
-          <div class="col-sm-5"><input type="time" step="300" name="horarios[<?= $d ?>][inicio][]" class="form-control" value="<?= $ini ?>"></div>
-          <div class="col-sm-5"><input type="time" step="300" name="horarios[<?= $d ?>][fin][]" class="form-control" value="<?= $fin ?>"></div>
-          <div class="col-sm-2"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>
+          <span class="block-label col-12">Bloque <?= $i + 1 ?></span>
+          <div class="col-sm-5">
+            <label>Inicio</label>
+            <input type="time" step="300" name="horarios[<?= $d ?>][inicio][]" class="form-control" value="<?= $ini ?>">
+          </div>
+          <div class="col-sm-5">
+            <label>Fin</label>
+            <input type="time" step="300" name="horarios[<?= $d ?>][fin][]" class="form-control" value="<?= $fin ?>">
+          </div>
+          <div class="col-sm-2 d-flex align-items-end"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>
         </div>
   <?php endforeach; else: ?>
         <div class="block form-group row">
-          <div class="col-sm-5"><input type="time" step="300" name="horarios[<?= $d ?>][inicio][]" class="form-control"></div>
-          <div class="col-sm-5"><input type="time" step="300" name="horarios[<?= $d ?>][fin][]" class="form-control"></div>
-          <div class="col-sm-2"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>
+          <span class="block-label col-12">Bloque 1</span>
+          <div class="col-sm-5">
+            <label>Inicio</label>
+            <input type="time" step="300" name="horarios[<?= $d ?>][inicio][]" class="form-control">
+          </div>
+          <div class="col-sm-5">
+            <label>Fin</label>
+            <input type="time" step="300" name="horarios[<?= $d ?>][fin][]" class="form-control">
+          </div>
+          <div class="col-sm-2 d-flex align-items-end"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>
         </div>
   <?php endif; ?>
       </div>

--- a/admin/nuevoAlmacen.php
+++ b/admin/nuevoAlmacen.php
@@ -78,6 +78,9 @@ if ( !empty($_POST)) {
               margin-top: 1.5rem;
               margin-bottom: 1rem;
             }
+            .block-label {
+              font-weight: bold;
+            }
           </style>
   </head>
   <body class="light-only">
@@ -173,9 +176,16 @@ if ( !empty($_POST)) {
     <h6><?= $diasSemana[$d] ?></h6>
     <div class="blocks">
       <div class="block form-group row">
-        <div class="col-sm-5"><input type="time" step="300" name="horarios[<?= $d ?>][inicio][]" class="form-control"></div>
-        <div class="col-sm-5"><input type="time" step="300" name="horarios[<?= $d ?>][fin][]" class="form-control"></div>
-        <div class="col-sm-2"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>
+        <span class="block-label col-12">Bloque 1</span>
+        <div class="col-sm-5">
+          <label>Inicio</label>
+          <input type="time" step="300" name="horarios[<?= $d ?>][inicio][]" class="form-control">
+        </div>
+        <div class="col-sm-5">
+          <label>Fin</label>
+          <input type="time" step="300" name="horarios[<?= $d ?>][fin][]" class="form-control">
+        </div>
+        <div class="col-sm-2 d-flex align-items-end"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>
       </div>
     </div>
     <button type="button" class="btn btn-secondary btn-sm add-block" data-day="<?= $d ?>">Agregar bloque</button>


### PR DESCRIPTION
## Summary
- Add visible "Bloque N" labels and Inicio/Fin time labels to schedule blocks in almacen forms.
- Introduce dynamic numbering for schedule blocks when adding or removing blocks.

## Testing
- `php -l admin/nuevoAlmacen.php`
- `php -l admin/modificarAlmacen.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68be11f655348321ba8b9c93dc39ff7c