### PR TITLE
Add layout variants for new warehouse form

### DIFF
--- a/admin/assets/js/horarios_acordeon.js
+++ b/admin/assets/js/horarios_acordeon.js
@@ -1,0 +1,25 @@
+document.addEventListener('click', function(e){
+  if (e.target.classList.contains('add-block')) {
+    var day = e.target.getAttribute('data-day');
+    var container = e.target.closest('.card-body').querySelector('.blocks');
+    var count = container.querySelectorAll('.block').length + 1;
+    var div = document.createElement('div');
+    div.className = 'block form-group row';
+    div.innerHTML =
+      '<span class="block-label col-12">Bloque ' + count + '</span>' +
+      '<div class="col-sm-5"><label>Inicio</label><input type="time" step="300" name="horarios[' + day + '][inicio][]" class="form-control"></div>' +
+      '<div class="col-sm-5"><label>Fin</label><input type="time" step="300" name="horarios[' + day + '][fin][]" class="form-control"></div>' +
+      '<div class="col-sm-2 d-flex align-items-end"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>';
+    container.appendChild(div);
+  }
+  if (e.target.classList.contains('remove-block')) {
+    var block = e.target.closest('.block');
+    if (block) {
+      var container = block.parentElement;
+      block.remove();
+      container.querySelectorAll('.block-label').forEach(function(label, idx){
+        label.textContent = 'Bloque ' + (idx + 1);
+      });
+    }
+  }
+});

--- a/admin/assets/js/horarios_compacto.js
+++ b/admin/assets/js/horarios_compacto.js
@@ -1,0 +1,25 @@
+document.addEventListener('click', function(e){
+  if (e.target.classList.contains('add-block')) {
+    var day = e.target.getAttribute('data-day');
+    var container = e.target.closest('.day-block').querySelector('.blocks');
+    var count = container.querySelectorAll('.block').length + 1;
+    var div = document.createElement('div');
+    div.className = 'block form-row align-items-end';
+    div.innerHTML =
+      '<span class="block-label col-12">Bloque ' + count + '</span>' +
+      '<div class="col-4"><label class="sr-only">Inicio</label><input type="time" step="300" name="horarios[' + day + '][inicio][]" class="form-control" placeholder="Inicio"></div>' +
+      '<div class="col-4"><label class="sr-only">Fin</label><input type="time" step="300" name="horarios[' + day + '][fin][]" class="form-control" placeholder="Fin"></div>' +
+      '<div class="col-2"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>';
+    container.appendChild(div);
+  }
+  if (e.target.classList.contains('remove-block')) {
+    var block = e.target.closest('.block');
+    if (block) {
+      var container = block.parentElement;
+      block.remove();
+      container.querySelectorAll('.block-label').forEach(function(label, idx){
+        label.textContent = 'Bloque ' + (idx + 1);
+      });
+    }
+  }
+});

--- a/admin/assets/js/horarios_tabla.js
+++ b/admin/assets/js/horarios_tabla.js
@@ -1,0 +1,23 @@
+document.addEventListener('click', function(e){
+  if (e.target.classList.contains('add-block')) {
+    var day = e.target.getAttribute('data-day');
+    var tbody = document.querySelector('#tablaHorarios tbody');
+    var rows = tbody.querySelectorAll('tr[data-day="' + day + '"]');
+    var lastRow = rows[rows.length - 1];
+    var tr = document.createElement('tr');
+    tr.setAttribute('data-day', day);
+    tr.innerHTML =
+      '<td></td>' +
+      '<td><input type="time" step="300" name="horarios[' + day + '][inicio][]" class="form-control"></td>' +
+      '<td><input type="time" step="300" name="horarios[' + day + '][fin][]" class="form-control"></td>' +
+      '<td><button type="button" class="btn btn-danger btn-sm remove-block">X</button></td>';
+    lastRow.parentNode.insertBefore(tr, lastRow.nextSibling);
+  }
+  if (e.target.classList.contains('remove-block')) {
+    var row = e.target.closest('tr');
+    if (row) {
+      row.remove();
+    }
+  }
+});
+

--- a/admin/assets/js/horarios_tabs.js
+++ b/admin/assets/js/horarios_tabs.js
@@ -1,0 +1,25 @@
+document.addEventListener('click', function(e){
+  if (e.target.classList.contains('add-block')) {
+    var day = e.target.getAttribute('data-day');
+    var container = e.target.closest('.day-block').querySelector('.blocks');
+    var count = container.querySelectorAll('.block').length + 1;
+    var div = document.createElement('div');
+    div.className = 'block form-group row';
+    div.innerHTML =
+      '<span class="block-label col-12">Bloque ' + count + '</span>' +
+      '<div class="col-sm-5"><label>Inicio</label><input type="time" step="300" name="horarios[' + day + '][inicio][]" class="form-control"></div>' +
+      '<div class="col-sm-5"><label>Fin</label><input type="time" step="300" name="horarios[' + day + '][fin][]" class="form-control"></div>' +
+      '<div class="col-sm-2 d-flex align-items-end"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>';
+    container.appendChild(div);
+  }
+  if (e.target.classList.contains('remove-block')) {
+    var block = e.target.closest('.block');
+    if (block) {
+      var container = block.parentElement;
+      block.remove();
+      container.querySelectorAll('.block-label').forEach(function(label, idx){
+        label.textContent = 'Bloque ' + (idx + 1);
+      });
+    }
+  }
+});

--- a/admin/nuevoAlmacen_acordeon.php
+++ b/admin/nuevoAlmacen_acordeon.php
@@ -1,0 +1,259 @@
+<?php
+require("config.php");
+if(empty($_SESSION['user'])){
+  header("Location: index.php");
+  die("Redirecting to index.php"); 
+}
+require 'database.php';
+
+$diasSemana = ['Lunes','Martes','Miércoles','Jueves','Viernes','Sábado','Domingo'];
+$horarios = [];
+
+if ( !empty($_POST)) {
+
+  // Validaciones de horarios
+  $errores = [];
+  $freq = isset($_POST['frecuencia_minutos']) ? (int)$_POST['frecuencia_minutos'] : 0;
+  $bloq = isset($_POST['bloqueo_minutos']) ? (int)$_POST['bloqueo_minutos'] : 0;
+  if ($freq <= 0 || $freq % 5 !== 0) {
+    $errores[] = 'Frecuencia inválida';
+  }
+  if ($bloq < $freq) {
+    $errores[] = 'Bloqueo inválido';
+  }
+  if (!empty($_POST['horarios'])) {
+    foreach ($_POST['horarios'] as $dia => $dataDia) {
+      $inicios = $dataDia['inicio'] ?? [];
+      $fines   = $dataDia['fin'] ?? [];
+      foreach ($inicios as $k => $ini) {
+        $fin = $fines[$k] ?? null;
+        if ($ini && $fin && $ini >= $fin) {
+          $errores[] = 'Hora inicio debe ser menor a hora fin para el día ' . $diasSemana[$dia];
+        }
+      }
+    }
+  }
+  if ($errores) {
+    echo implode('<br>', $errores);
+    exit;
+  }
+
+  // insert data
+  $pdo = Database::connect();
+  $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+  $pdo->beginTransaction();
+
+  $sql = "INSERT INTO almacenes(almacen, iniciales_codigo_productos, direccion, punto_venta, id_tipo, activo) VALUES (?,?,?,?,?,1)";
+  $q = $pdo->prepare($sql);
+  $q->execute(array($_POST['almacen'],$_POST['iniciales_codigo_productos'],$_POST['direccion'],$_POST['punto_venta'],$_POST['id_tipo']));
+  $idAlmacen = $pdo->lastInsertId();
+
+  if (!empty($_POST['horarios'])) {
+    $sqlH = "INSERT INTO almacenes_horarios(id_almacen,dia_semana,hora_inicio,hora_fin,frecuencia_minutos,bloqueo_minutos) VALUES (?,?,?,?,?,?)";
+    $qH = $pdo->prepare($sqlH);
+    foreach ($_POST['horarios'] as $dia => $dataDia) {
+      $inicios = $dataDia['inicio'] ?? [];
+      $fines   = $dataDia['fin'] ?? [];
+      foreach ($inicios as $k => $ini) {
+        $fin = $fines[$k] ?? null;
+        if ($ini && $fin) {
+          $qH->execute(array($idAlmacen,$dia,$ini,$fin,$freq,$bloq));
+        }
+      }
+    }
+  }
+
+  $pdo->commit();
+  Database::disconnect();
+
+  header("Location: listarAlmacenes.php");
+}?>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <?php include('head_forms.php');?>
+          <link rel="stylesheet" type="text/css" href="assets/css/select2.css">
+          <style>
+            .schedule-title {
+              margin-top: 1.5rem;
+              margin-bottom: 1rem;
+            }
+            .block-label {
+              font-weight: bold;
+            }
+          </style>
+  </head>
+  <body class="light-only">
+    <!-- Loader ends-->
+    <!-- page-wrapper Start-->
+    <div class="page-wrapper">
+	    <?php include('header.php');?>
+	  
+      <!-- Page Header Start-->
+      <div class="page-body-wrapper">
+		    <?php include('menu.php');?>
+        <!-- Page Sidebar Start-->
+        <!-- Right sidebar Ends-->
+        <div class="page-body">
+          <div class="container-fluid">
+            <div class="page-header">
+              <div class="row">
+                <div class="col-10">
+                  <div class="page-header-left">
+                    <h3><?php include("title.php"); ?></h3>
+                    <ol class="breadcrumb">
+                      <li class="breadcrumb-item"><a href="#"><i data-feather="home"></i></a></li>
+                      <li class="breadcrumb-item">Nuevo Almacen</li>
+                    </ol>
+                  </div>
+                </div>
+                <!-- Bookmark Start-->
+                <div class="col-2">
+                  <div class="bookmark pull-right">
+                    <ul>
+                      <li><a  target="_blank" data-container="body" data-toggle="popover" data-placement="top" title="" data-original-title="<?php echo date('d-m-Y');?>"><i data-feather="calendar"></i></a></li>
+                    </ul>
+                  </div>
+                </div>
+                <!-- Bookmark Ends-->
+              </div>
+            </div>
+          </div>
+          <!-- Container-fluid starts-->
+          <div class="container-fluid">
+            <div class="row">
+              <div class="col-sm-12">
+                <div class="card">
+                  <div class="card-header">
+                    <h5>Nuevo Almacen</h5>
+                  </div>
+				          <form class="form theme-form" role="form" method="post" action="nuevoAlmacen.php">
+                    <div class="card-body">
+                      <div class="row">
+                        <div class="col">
+						
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Almacen</label>
+                            <div class="col-sm-9"><input name="almacen" type="text" maxlength="99" class="form-control" value="" required="required"></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Iniciales para los codigos de productos</label>
+                            <div class="col-sm-9"><input name="iniciales_codigo_productos" type="text" maxlength="2" class="form-control" value="" required="required" oninput="convertirAMayusculas(this)"></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Tipo de almacen</label>
+                            <div class="col-sm-9">
+                              <select name="id_tipo" id="id_tipo" class="js-example-basic-single col-sm-12" required>
+                                <option value="">Seleccione...</option>
+                                <option value="1">Venta</option>
+                                <option value="2">Deposito</option>
+                              </select>
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Direccion</label>
+                            <div class="col-sm-9"><input name="direccion" type="text" maxlength="99" class="form-control" value=""></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Punto de venta Facturacion Electrónica</label>
+                            <div class="col-sm-9"><input name="punto_venta" type="number" maxlength="99" class="form-control" value=""></div>
+                          </div>
+                          <h5 class="schedule-title">Configuración de horarios</h5>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">
+                              Frecuencia (min)
+                              <i class="fa fa-info-circle ml-1" data-toggle="tooltip" data-placement="top" title="Intervalo entre turnos (múltiplos de 5 minutos)"></i>
+                            </label>
+                            <div class="col-sm-3"><input type="number" step="5" name="frecuencia_minutos" class="form-control"></div>
+                            <label class="col-sm-3 col-form-label">
+                              Bloqueo (min)
+                              <i class="fa fa-info-circle ml-1" data-toggle="tooltip" data-placement="top" title="Minutos adicionales bloqueados tras un turno reservado"></i>
+                            </label>
+                            <div class="col-sm-3"><input type="number" name="bloqueo_minutos" class="form-control"></div>
+                          </div>
+<div class="accordion" id="accordionHorarios">
+<?php for($d=0;$d<7;$d++): ?>
+  <div class="card">
+    <div class="card-header" id="heading<?= $d ?>">
+      <h2 class="mb-0">
+        <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapse<?= $d ?>" aria-expanded="<?= $d==0 ? 'true' : 'false' ?>" aria-controls="collapse<?= $d ?>">
+          <?= $diasSemana[$d] ?>
+        </button>
+      </h2>
+    </div>
+    <div id="collapse<?= $d ?>" class="collapse<?= $d==0 ? ' show' : '' ?>" aria-labelledby="heading<?= $d ?>" data-parent="#accordionHorarios">
+      <div class="card-body">
+        <div class="blocks">
+          <div class="block form-group row">
+            <span class="block-label col-12">Bloque 1</span>
+            <div class="col-sm-5">
+              <label>Inicio</label>
+              <input type="time" step="300" name="horarios[<?= $d ?>][inicio][]" class="form-control">
+            </div>
+            <div class="col-sm-5">
+              <label>Fin</label>
+              <input type="time" step="300" name="horarios[<?= $d ?>][fin][]" class="form-control">
+            </div>
+            <div class="col-sm-2 d-flex align-items-end"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>
+          </div>
+        </div>
+        <button type="button" class="btn btn-secondary btn-sm add-block" data-day="<?= $d ?>">Agregar bloque</button>
+      </div>
+    </div>
+  </div>
+<?php endfor; ?>
+</div>
+
+                        </div>
+                      </div>
+                    </div>
+                    <div class="card-footer">
+                      <div class="col-sm-9 offset-sm-3">
+                        <button class="btn btn-primary" type="submit">Crear</button>
+						            <a href="listarAlmacenes.php" class="btn btn-light">Volver</a>
+                      </div>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- Container-fluid Ends-->
+        </div>
+        <!-- footer start-->
+		    <?php include("footer.php"); ?>
+      </div>
+    </div>
+    <!-- latest jquery-->
+    <script src="assets/js/jquery-3.2.1.min.js"></script>
+    <!-- Bootstrap js-->
+    <script src="assets/js/bootstrap/popper.min.js"></script>
+    <script src="assets/js/bootstrap/bootstrap.js"></script>
+    <!-- feather icon js-->
+    <script src="assets/js/icons/feather-icon/feather.min.js"></script>
+    <script src="assets/js/icons/feather-icon/feather-icon.js"></script>
+    <!-- Sidebar jquery-->
+    <script src="assets/js/sidebar-menu.js"></script>
+    <script src="assets/js/config.js"></script>
+    <!-- Plugins JS start-->
+    <script src="assets/js/typeahead/handlebars.js"></script>
+    <script src="assets/js/typeahead/typeahead.bundle.js"></script>
+    <script src="assets/js/typeahead/typeahead.custom.js"></script>
+    <script src="assets/js/chat-menu.js"></script>
+    <script src="assets/js/tooltip-init.js"></script>
+    <script src="assets/js/typeahead-search/handlebars.js"></script>
+    <script src="assets/js/typeahead-search/typeahead-custom.js"></script>
+    <!-- Plugins JS Ends-->
+    <!-- Theme js-->
+    <script src="assets/js/script.js"></script>
+      <!-- Plugin used-->
+            <script src="assets/js/select2/select2.full.min.js"></script>
+      <script src="assets/js/select2/select2-custom.js"></script>
+      <script src="assets/js/horarios_acordeon.js"></script>
+      <script>
+        function convertirAMayusculas(input) {
+          input.value = input.value.toUpperCase();
+        }
+      </script>
+  </body>
+</html>

--- a/admin/nuevoAlmacen_compacto.php
+++ b/admin/nuevoAlmacen_compacto.php
@@ -1,0 +1,247 @@
+<?php
+require("config.php");
+if(empty($_SESSION['user'])){
+  header("Location: index.php");
+  die("Redirecting to index.php"); 
+}
+require 'database.php';
+
+$diasSemana = ['Lunes','Martes','Miércoles','Jueves','Viernes','Sábado','Domingo'];
+$horarios = [];
+
+if ( !empty($_POST)) {
+
+  // Validaciones de horarios
+  $errores = [];
+  $freq = isset($_POST['frecuencia_minutos']) ? (int)$_POST['frecuencia_minutos'] : 0;
+  $bloq = isset($_POST['bloqueo_minutos']) ? (int)$_POST['bloqueo_minutos'] : 0;
+  if ($freq <= 0 || $freq % 5 !== 0) {
+    $errores[] = 'Frecuencia inválida';
+  }
+  if ($bloq < $freq) {
+    $errores[] = 'Bloqueo inválido';
+  }
+  if (!empty($_POST['horarios'])) {
+    foreach ($_POST['horarios'] as $dia => $dataDia) {
+      $inicios = $dataDia['inicio'] ?? [];
+      $fines   = $dataDia['fin'] ?? [];
+      foreach ($inicios as $k => $ini) {
+        $fin = $fines[$k] ?? null;
+        if ($ini && $fin && $ini >= $fin) {
+          $errores[] = 'Hora inicio debe ser menor a hora fin para el día ' . $diasSemana[$dia];
+        }
+      }
+    }
+  }
+  if ($errores) {
+    echo implode('<br>', $errores);
+    exit;
+  }
+
+  // insert data
+  $pdo = Database::connect();
+  $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+  $pdo->beginTransaction();
+
+  $sql = "INSERT INTO almacenes(almacen, iniciales_codigo_productos, direccion, punto_venta, id_tipo, activo) VALUES (?,?,?,?,?,1)";
+  $q = $pdo->prepare($sql);
+  $q->execute(array($_POST['almacen'],$_POST['iniciales_codigo_productos'],$_POST['direccion'],$_POST['punto_venta'],$_POST['id_tipo']));
+  $idAlmacen = $pdo->lastInsertId();
+
+  if (!empty($_POST['horarios'])) {
+    $sqlH = "INSERT INTO almacenes_horarios(id_almacen,dia_semana,hora_inicio,hora_fin,frecuencia_minutos,bloqueo_minutos) VALUES (?,?,?,?,?,?)";
+    $qH = $pdo->prepare($sqlH);
+    foreach ($_POST['horarios'] as $dia => $dataDia) {
+      $inicios = $dataDia['inicio'] ?? [];
+      $fines   = $dataDia['fin'] ?? [];
+      foreach ($inicios as $k => $ini) {
+        $fin = $fines[$k] ?? null;
+        if ($ini && $fin) {
+          $qH->execute(array($idAlmacen,$dia,$ini,$fin,$freq,$bloq));
+        }
+      }
+    }
+  }
+
+  $pdo->commit();
+  Database::disconnect();
+
+  header("Location: listarAlmacenes.php");
+}?>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <?php include('head_forms.php');?>
+          <link rel="stylesheet" type="text/css" href="assets/css/select2.css">
+          <style>
+            .schedule-title {
+              margin-top: 1.5rem;
+              margin-bottom: 1rem;
+            }
+            .block-label {
+              font-weight: bold;
+            }
+          </style>
+  </head>
+  <body class="light-only">
+    <!-- Loader ends-->
+    <!-- page-wrapper Start-->
+    <div class="page-wrapper">
+	    <?php include('header.php');?>
+	  
+      <!-- Page Header Start-->
+      <div class="page-body-wrapper">
+		    <?php include('menu.php');?>
+        <!-- Page Sidebar Start-->
+        <!-- Right sidebar Ends-->
+        <div class="page-body">
+          <div class="container-fluid">
+            <div class="page-header">
+              <div class="row">
+                <div class="col-10">
+                  <div class="page-header-left">
+                    <h3><?php include("title.php"); ?></h3>
+                    <ol class="breadcrumb">
+                      <li class="breadcrumb-item"><a href="#"><i data-feather="home"></i></a></li>
+                      <li class="breadcrumb-item">Nuevo Almacen</li>
+                    </ol>
+                  </div>
+                </div>
+                <!-- Bookmark Start-->
+                <div class="col-2">
+                  <div class="bookmark pull-right">
+                    <ul>
+                      <li><a  target="_blank" data-container="body" data-toggle="popover" data-placement="top" title="" data-original-title="<?php echo date('d-m-Y');?>"><i data-feather="calendar"></i></a></li>
+                    </ul>
+                  </div>
+                </div>
+                <!-- Bookmark Ends-->
+              </div>
+            </div>
+          </div>
+          <!-- Container-fluid starts-->
+          <div class="container-fluid">
+            <div class="row">
+              <div class="col-sm-12">
+                <div class="card">
+                  <div class="card-header">
+                    <h5>Nuevo Almacen</h5>
+                  </div>
+				          <form class="form theme-form" role="form" method="post" action="nuevoAlmacen.php">
+                    <div class="card-body">
+                      <div class="row">
+                        <div class="col">
+						
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Almacen</label>
+                            <div class="col-sm-9"><input name="almacen" type="text" maxlength="99" class="form-control" value="" required="required"></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Iniciales para los codigos de productos</label>
+                            <div class="col-sm-9"><input name="iniciales_codigo_productos" type="text" maxlength="2" class="form-control" value="" required="required" oninput="convertirAMayusculas(this)"></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Tipo de almacen</label>
+                            <div class="col-sm-9">
+                              <select name="id_tipo" id="id_tipo" class="js-example-basic-single col-sm-12" required>
+                                <option value="">Seleccione...</option>
+                                <option value="1">Venta</option>
+                                <option value="2">Deposito</option>
+                              </select>
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Direccion</label>
+                            <div class="col-sm-9"><input name="direccion" type="text" maxlength="99" class="form-control" value=""></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Punto de venta Facturacion Electrónica</label>
+                            <div class="col-sm-9"><input name="punto_venta" type="number" maxlength="99" class="form-control" value=""></div>
+                          </div>
+                          <h5 class="schedule-title">Configuración de horarios</h5>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">
+                              Frecuencia (min)
+                              <i class="fa fa-info-circle ml-1" data-toggle="tooltip" data-placement="top" title="Intervalo entre turnos (múltiplos de 5 minutos)"></i>
+                            </label>
+                            <div class="col-sm-3"><input type="number" step="5" name="frecuencia_minutos" class="form-control"></div>
+                            <label class="col-sm-3 col-form-label">
+                              Bloqueo (min)
+                              <i class="fa fa-info-circle ml-1" data-toggle="tooltip" data-placement="top" title="Minutos adicionales bloqueados tras un turno reservado"></i>
+                            </label>
+                            <div class="col-sm-3"><input type="number" name="bloqueo_minutos" class="form-control"></div>
+                          </div>
+<?php for($d=0;$d<7;$d++): ?>
+  <div class="day-block mb-3 border p-3">
+    <h6><?= $diasSemana[$d] ?></h6>
+    <div class="blocks">
+      <div class="block form-row align-items-end">
+        <span class="block-label col-12">Bloque 1</span>
+        <div class="col-4">
+          <label class="sr-only">Inicio</label>
+          <input type="time" step="300" name="horarios[<?= $d ?>][inicio][]" class="form-control" placeholder="Inicio">
+        </div>
+        <div class="col-4">
+          <label class="sr-only">Fin</label>
+          <input type="time" step="300" name="horarios[<?= $d ?>][fin][]" class="form-control" placeholder="Fin">
+        </div>
+        <div class="col-2"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>
+      </div>
+    </div>
+    <button type="button" class="btn btn-secondary btn-sm add-block" data-day="<?= $d ?>">Agregar bloque</button>
+  </div>
+<?php endfor; ?>
+
+                        </div>
+                      </div>
+                    </div>
+                    <div class="card-footer">
+                      <div class="col-sm-9 offset-sm-3">
+                        <button class="btn btn-primary" type="submit">Crear</button>
+						            <a href="listarAlmacenes.php" class="btn btn-light">Volver</a>
+                      </div>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- Container-fluid Ends-->
+        </div>
+        <!-- footer start-->
+		    <?php include("footer.php"); ?>
+      </div>
+    </div>
+    <!-- latest jquery-->
+    <script src="assets/js/jquery-3.2.1.min.js"></script>
+    <!-- Bootstrap js-->
+    <script src="assets/js/bootstrap/popper.min.js"></script>
+    <script src="assets/js/bootstrap/bootstrap.js"></script>
+    <!-- feather icon js-->
+    <script src="assets/js/icons/feather-icon/feather.min.js"></script>
+    <script src="assets/js/icons/feather-icon/feather-icon.js"></script>
+    <!-- Sidebar jquery-->
+    <script src="assets/js/sidebar-menu.js"></script>
+    <script src="assets/js/config.js"></script>
+    <!-- Plugins JS start-->
+    <script src="assets/js/typeahead/handlebars.js"></script>
+    <script src="assets/js/typeahead/typeahead.bundle.js"></script>
+    <script src="assets/js/typeahead/typeahead.custom.js"></script>
+    <script src="assets/js/chat-menu.js"></script>
+    <script src="assets/js/tooltip-init.js"></script>
+    <script src="assets/js/typeahead-search/handlebars.js"></script>
+    <script src="assets/js/typeahead-search/typeahead-custom.js"></script>
+    <!-- Plugins JS Ends-->
+    <!-- Theme js-->
+    <script src="assets/js/script.js"></script>
+      <!-- Plugin used-->
+            <script src="assets/js/select2/select2.full.min.js"></script>
+      <script src="assets/js/select2/select2-custom.js"></script>
+      <script src="assets/js/horarios_compacto.js"></script>
+      <script>
+        function convertirAMayusculas(input) {
+          input.value = input.value.toUpperCase();
+        }
+      </script>
+  </body>
+</html>

--- a/admin/nuevoAlmacen_tabla.php
+++ b/admin/nuevoAlmacen_tabla.php
@@ -1,0 +1,245 @@
+<?php
+require("config.php");
+if(empty($_SESSION['user'])){
+  header("Location: index.php");
+  die("Redirecting to index.php"); 
+}
+require 'database.php';
+
+$diasSemana = ['Lunes','Martes','Miércoles','Jueves','Viernes','Sábado','Domingo'];
+$horarios = [];
+
+if ( !empty($_POST)) {
+
+  // Validaciones de horarios
+  $errores = [];
+  $freq = isset($_POST['frecuencia_minutos']) ? (int)$_POST['frecuencia_minutos'] : 0;
+  $bloq = isset($_POST['bloqueo_minutos']) ? (int)$_POST['bloqueo_minutos'] : 0;
+  if ($freq <= 0 || $freq % 5 !== 0) {
+    $errores[] = 'Frecuencia inválida';
+  }
+  if ($bloq < $freq) {
+    $errores[] = 'Bloqueo inválido';
+  }
+  if (!empty($_POST['horarios'])) {
+    foreach ($_POST['horarios'] as $dia => $dataDia) {
+      $inicios = $dataDia['inicio'] ?? [];
+      $fines   = $dataDia['fin'] ?? [];
+      foreach ($inicios as $k => $ini) {
+        $fin = $fines[$k] ?? null;
+        if ($ini && $fin && $ini >= $fin) {
+          $errores[] = 'Hora inicio debe ser menor a hora fin para el día ' . $diasSemana[$dia];
+        }
+      }
+    }
+  }
+  if ($errores) {
+    echo implode('<br>', $errores);
+    exit;
+  }
+
+  // insert data
+  $pdo = Database::connect();
+  $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+  $pdo->beginTransaction();
+
+  $sql = "INSERT INTO almacenes(almacen, iniciales_codigo_productos, direccion, punto_venta, id_tipo, activo) VALUES (?,?,?,?,?,1)";
+  $q = $pdo->prepare($sql);
+  $q->execute(array($_POST['almacen'],$_POST['iniciales_codigo_productos'],$_POST['direccion'],$_POST['punto_venta'],$_POST['id_tipo']));
+  $idAlmacen = $pdo->lastInsertId();
+
+  if (!empty($_POST['horarios'])) {
+    $sqlH = "INSERT INTO almacenes_horarios(id_almacen,dia_semana,hora_inicio,hora_fin,frecuencia_minutos,bloqueo_minutos) VALUES (?,?,?,?,?,?)";
+    $qH = $pdo->prepare($sqlH);
+    foreach ($_POST['horarios'] as $dia => $dataDia) {
+      $inicios = $dataDia['inicio'] ?? [];
+      $fines   = $dataDia['fin'] ?? [];
+      foreach ($inicios as $k => $ini) {
+        $fin = $fines[$k] ?? null;
+        if ($ini && $fin) {
+          $qH->execute(array($idAlmacen,$dia,$ini,$fin,$freq,$bloq));
+        }
+      }
+    }
+  }
+
+  $pdo->commit();
+  Database::disconnect();
+
+  header("Location: listarAlmacenes.php");
+}?>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <?php include('head_forms.php');?>
+          <link rel="stylesheet" type="text/css" href="assets/css/select2.css">
+          <style>
+            .schedule-title {
+              margin-top: 1.5rem;
+              margin-bottom: 1rem;
+            }
+            .block-label {
+              font-weight: bold;
+            }
+          </style>
+  </head>
+  <body class="light-only">
+    <!-- Loader ends-->
+    <!-- page-wrapper Start-->
+    <div class="page-wrapper">
+	    <?php include('header.php');?>
+	  
+      <!-- Page Header Start-->
+      <div class="page-body-wrapper">
+		    <?php include('menu.php');?>
+        <!-- Page Sidebar Start-->
+        <!-- Right sidebar Ends-->
+        <div class="page-body">
+          <div class="container-fluid">
+            <div class="page-header">
+              <div class="row">
+                <div class="col-10">
+                  <div class="page-header-left">
+                    <h3><?php include("title.php"); ?></h3>
+                    <ol class="breadcrumb">
+                      <li class="breadcrumb-item"><a href="#"><i data-feather="home"></i></a></li>
+                      <li class="breadcrumb-item">Nuevo Almacen</li>
+                    </ol>
+                  </div>
+                </div>
+                <!-- Bookmark Start-->
+                <div class="col-2">
+                  <div class="bookmark pull-right">
+                    <ul>
+                      <li><a  target="_blank" data-container="body" data-toggle="popover" data-placement="top" title="" data-original-title="<?php echo date('d-m-Y');?>"><i data-feather="calendar"></i></a></li>
+                    </ul>
+                  </div>
+                </div>
+                <!-- Bookmark Ends-->
+              </div>
+            </div>
+          </div>
+          <!-- Container-fluid starts-->
+          <div class="container-fluid">
+            <div class="row">
+              <div class="col-sm-12">
+                <div class="card">
+                  <div class="card-header">
+                    <h5>Nuevo Almacen</h5>
+                  </div>
+				          <form class="form theme-form" role="form" method="post" action="nuevoAlmacen.php">
+                    <div class="card-body">
+                      <div class="row">
+                        <div class="col">
+						
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Almacen</label>
+                            <div class="col-sm-9"><input name="almacen" type="text" maxlength="99" class="form-control" value="" required="required"></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Iniciales para los codigos de productos</label>
+                            <div class="col-sm-9"><input name="iniciales_codigo_productos" type="text" maxlength="2" class="form-control" value="" required="required" oninput="convertirAMayusculas(this)"></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Tipo de almacen</label>
+                            <div class="col-sm-9">
+                              <select name="id_tipo" id="id_tipo" class="js-example-basic-single col-sm-12" required>
+                                <option value="">Seleccione...</option>
+                                <option value="1">Venta</option>
+                                <option value="2">Deposito</option>
+                              </select>
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Direccion</label>
+                            <div class="col-sm-9"><input name="direccion" type="text" maxlength="99" class="form-control" value=""></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Punto de venta Facturacion Electrónica</label>
+                            <div class="col-sm-9"><input name="punto_venta" type="number" maxlength="99" class="form-control" value=""></div>
+                          </div>
+                          <h5 class="schedule-title">Configuración de horarios</h5>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">
+                              Frecuencia (min)
+                              <i class="fa fa-info-circle ml-1" data-toggle="tooltip" data-placement="top" title="Intervalo entre turnos (múltiplos de 5 minutos)"></i>
+                            </label>
+                            <div class="col-sm-3"><input type="number" step="5" name="frecuencia_minutos" class="form-control"></div>
+                            <label class="col-sm-3 col-form-label">
+                              Bloqueo (min)
+                              <i class="fa fa-info-circle ml-1" data-toggle="tooltip" data-placement="top" title="Minutos adicionales bloqueados tras un turno reservado"></i>
+                            </label>
+                            <div class="col-sm-3"><input type="number" name="bloqueo_minutos" class="form-control"></div>
+                          </div>
+<table class="table table-bordered" id="tablaHorarios">
+  <thead>
+    <tr><th>Día</th><th>Inicio</th><th>Fin</th><th>Acciones</th></tr>
+  </thead>
+  <tbody>
+<?php for($d=0;$d<7;$d++): ?>
+    <tr data-day="<?= $d ?>">
+      <td><?= $diasSemana[$d] ?></td>
+      <td><input type="time" step="300" name="horarios[<?= $d ?>][inicio][]" class="form-control"></td>
+      <td><input type="time" step="300" name="horarios[<?= $d ?>][fin][]" class="form-control"></td>
+      <td>
+        <button type="button" class="btn btn-secondary btn-sm add-block" data-day="<?= $d ?>">+</button>
+        <button type="button" class="btn btn-danger btn-sm remove-block">X</button>
+      </td>
+    </tr>
+<?php endfor; ?>
+  </tbody>
+</table>
+
+                        </div>
+                      </div>
+                    </div>
+                    <div class="card-footer">
+                      <div class="col-sm-9 offset-sm-3">
+                        <button class="btn btn-primary" type="submit">Crear</button>
+						            <a href="listarAlmacenes.php" class="btn btn-light">Volver</a>
+                      </div>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- Container-fluid Ends-->
+        </div>
+        <!-- footer start-->
+		    <?php include("footer.php"); ?>
+      </div>
+    </div>
+    <!-- latest jquery-->
+    <script src="assets/js/jquery-3.2.1.min.js"></script>
+    <!-- Bootstrap js-->
+    <script src="assets/js/bootstrap/popper.min.js"></script>
+    <script src="assets/js/bootstrap/bootstrap.js"></script>
+    <!-- feather icon js-->
+    <script src="assets/js/icons/feather-icon/feather.min.js"></script>
+    <script src="assets/js/icons/feather-icon/feather-icon.js"></script>
+    <!-- Sidebar jquery-->
+    <script src="assets/js/sidebar-menu.js"></script>
+    <script src="assets/js/config.js"></script>
+    <!-- Plugins JS start-->
+    <script src="assets/js/typeahead/handlebars.js"></script>
+    <script src="assets/js/typeahead/typeahead.bundle.js"></script>
+    <script src="assets/js/typeahead/typeahead.custom.js"></script>
+    <script src="assets/js/chat-menu.js"></script>
+    <script src="assets/js/tooltip-init.js"></script>
+    <script src="assets/js/typeahead-search/handlebars.js"></script>
+    <script src="assets/js/typeahead-search/typeahead-custom.js"></script>
+    <!-- Plugins JS Ends-->
+    <!-- Theme js-->
+    <script src="assets/js/script.js"></script>
+      <!-- Plugin used-->
+            <script src="assets/js/select2/select2.full.min.js"></script>
+      <script src="assets/js/select2/select2-custom.js"></script>
+      <script src="assets/js/horarios_tabla.js"></script>
+      <script>
+        function convertirAMayusculas(input) {
+          input.value = input.value.toUpperCase();
+        }
+      </script>
+  </body>
+</html>

--- a/admin/nuevoAlmacen_tabs.php
+++ b/admin/nuevoAlmacen_tabs.php
@@ -1,0 +1,257 @@
+<?php
+require("config.php");
+if(empty($_SESSION['user'])){
+  header("Location: index.php");
+  die("Redirecting to index.php"); 
+}
+require 'database.php';
+
+$diasSemana = ['Lunes','Martes','Miércoles','Jueves','Viernes','Sábado','Domingo'];
+$horarios = [];
+
+if ( !empty($_POST)) {
+
+  // Validaciones de horarios
+  $errores = [];
+  $freq = isset($_POST['frecuencia_minutos']) ? (int)$_POST['frecuencia_minutos'] : 0;
+  $bloq = isset($_POST['bloqueo_minutos']) ? (int)$_POST['bloqueo_minutos'] : 0;
+  if ($freq <= 0 || $freq % 5 !== 0) {
+    $errores[] = 'Frecuencia inválida';
+  }
+  if ($bloq < $freq) {
+    $errores[] = 'Bloqueo inválido';
+  }
+  if (!empty($_POST['horarios'])) {
+    foreach ($_POST['horarios'] as $dia => $dataDia) {
+      $inicios = $dataDia['inicio'] ?? [];
+      $fines   = $dataDia['fin'] ?? [];
+      foreach ($inicios as $k => $ini) {
+        $fin = $fines[$k] ?? null;
+        if ($ini && $fin && $ini >= $fin) {
+          $errores[] = 'Hora inicio debe ser menor a hora fin para el día ' . $diasSemana[$dia];
+        }
+      }
+    }
+  }
+  if ($errores) {
+    echo implode('<br>', $errores);
+    exit;
+  }
+
+  // insert data
+  $pdo = Database::connect();
+  $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+  $pdo->beginTransaction();
+
+  $sql = "INSERT INTO almacenes(almacen, iniciales_codigo_productos, direccion, punto_venta, id_tipo, activo) VALUES (?,?,?,?,?,1)";
+  $q = $pdo->prepare($sql);
+  $q->execute(array($_POST['almacen'],$_POST['iniciales_codigo_productos'],$_POST['direccion'],$_POST['punto_venta'],$_POST['id_tipo']));
+  $idAlmacen = $pdo->lastInsertId();
+
+  if (!empty($_POST['horarios'])) {
+    $sqlH = "INSERT INTO almacenes_horarios(id_almacen,dia_semana,hora_inicio,hora_fin,frecuencia_minutos,bloqueo_minutos) VALUES (?,?,?,?,?,?)";
+    $qH = $pdo->prepare($sqlH);
+    foreach ($_POST['horarios'] as $dia => $dataDia) {
+      $inicios = $dataDia['inicio'] ?? [];
+      $fines   = $dataDia['fin'] ?? [];
+      foreach ($inicios as $k => $ini) {
+        $fin = $fines[$k] ?? null;
+        if ($ini && $fin) {
+          $qH->execute(array($idAlmacen,$dia,$ini,$fin,$freq,$bloq));
+        }
+      }
+    }
+  }
+
+  $pdo->commit();
+  Database::disconnect();
+
+  header("Location: listarAlmacenes.php");
+}?>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <?php include('head_forms.php');?>
+          <link rel="stylesheet" type="text/css" href="assets/css/select2.css">
+          <style>
+            .schedule-title {
+              margin-top: 1.5rem;
+              margin-bottom: 1rem;
+            }
+            .block-label {
+              font-weight: bold;
+            }
+          </style>
+  </head>
+  <body class="light-only">
+    <!-- Loader ends-->
+    <!-- page-wrapper Start-->
+    <div class="page-wrapper">
+	    <?php include('header.php');?>
+	  
+      <!-- Page Header Start-->
+      <div class="page-body-wrapper">
+		    <?php include('menu.php');?>
+        <!-- Page Sidebar Start-->
+        <!-- Right sidebar Ends-->
+        <div class="page-body">
+          <div class="container-fluid">
+            <div class="page-header">
+              <div class="row">
+                <div class="col-10">
+                  <div class="page-header-left">
+                    <h3><?php include("title.php"); ?></h3>
+                    <ol class="breadcrumb">
+                      <li class="breadcrumb-item"><a href="#"><i data-feather="home"></i></a></li>
+                      <li class="breadcrumb-item">Nuevo Almacen</li>
+                    </ol>
+                  </div>
+                </div>
+                <!-- Bookmark Start-->
+                <div class="col-2">
+                  <div class="bookmark pull-right">
+                    <ul>
+                      <li><a  target="_blank" data-container="body" data-toggle="popover" data-placement="top" title="" data-original-title="<?php echo date('d-m-Y');?>"><i data-feather="calendar"></i></a></li>
+                    </ul>
+                  </div>
+                </div>
+                <!-- Bookmark Ends-->
+              </div>
+            </div>
+          </div>
+          <!-- Container-fluid starts-->
+          <div class="container-fluid">
+            <div class="row">
+              <div class="col-sm-12">
+                <div class="card">
+                  <div class="card-header">
+                    <h5>Nuevo Almacen</h5>
+                  </div>
+				          <form class="form theme-form" role="form" method="post" action="nuevoAlmacen.php">
+                    <div class="card-body">
+                      <div class="row">
+                        <div class="col">
+						
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Almacen</label>
+                            <div class="col-sm-9"><input name="almacen" type="text" maxlength="99" class="form-control" value="" required="required"></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Iniciales para los codigos de productos</label>
+                            <div class="col-sm-9"><input name="iniciales_codigo_productos" type="text" maxlength="2" class="form-control" value="" required="required" oninput="convertirAMayusculas(this)"></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Tipo de almacen</label>
+                            <div class="col-sm-9">
+                              <select name="id_tipo" id="id_tipo" class="js-example-basic-single col-sm-12" required>
+                                <option value="">Seleccione...</option>
+                                <option value="1">Venta</option>
+                                <option value="2">Deposito</option>
+                              </select>
+                            </div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Direccion</label>
+                            <div class="col-sm-9"><input name="direccion" type="text" maxlength="99" class="form-control" value=""></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Punto de venta Facturacion Electrónica</label>
+                            <div class="col-sm-9"><input name="punto_venta" type="number" maxlength="99" class="form-control" value=""></div>
+                          </div>
+                          <h5 class="schedule-title">Configuración de horarios</h5>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">
+                              Frecuencia (min)
+                              <i class="fa fa-info-circle ml-1" data-toggle="tooltip" data-placement="top" title="Intervalo entre turnos (múltiplos de 5 minutos)"></i>
+                            </label>
+                            <div class="col-sm-3"><input type="number" step="5" name="frecuencia_minutos" class="form-control"></div>
+                            <label class="col-sm-3 col-form-label">
+                              Bloqueo (min)
+                              <i class="fa fa-info-circle ml-1" data-toggle="tooltip" data-placement="top" title="Minutos adicionales bloqueados tras un turno reservado"></i>
+                            </label>
+                            <div class="col-sm-3"><input type="number" name="bloqueo_minutos" class="form-control"></div>
+                          </div>
+<ul class="nav nav-tabs" id="dayTabs" role="tablist">
+<?php for($d=0;$d<7;$d++): ?>
+  <li class="nav-item">
+    <a class="nav-link<?= $d==0 ? ' active' : '' ?>" id="tab<?= $d ?>-tab" data-toggle="tab" href="#tab<?= $d ?>" role="tab" aria-controls="tab<?= $d ?>" aria-selected="<?= $d==0 ? 'true' : 'false' ?>"><?= $diasSemana[$d] ?></a>
+  </li>
+<?php endfor; ?>
+</ul>
+<div class="tab-content" id="dayTabsContent">
+<?php for($d=0;$d<7;$d++): ?>
+  <div class="tab-pane fade<?= $d==0 ? ' show active' : '' ?>" id="tab<?= $d ?>" role="tabpanel" aria-labelledby="tab<?= $d ?>-tab">
+    <div class="day-block p-3">
+      <div class="blocks">
+        <div class="block form-group row">
+          <span class="block-label col-12">Bloque 1</span>
+          <div class="col-sm-5">
+            <label>Inicio</label>
+            <input type="time" step="300" name="horarios[<?= $d ?>][inicio][]" class="form-control">
+          </div>
+          <div class="col-sm-5">
+            <label>Fin</label>
+            <input type="time" step="300" name="horarios[<?= $d ?>][fin][]" class="form-control">
+          </div>
+          <div class="col-sm-2 d-flex align-items-end"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>
+        </div>
+      </div>
+      <button type="button" class="btn btn-secondary btn-sm add-block" data-day="<?= $d ?>">Agregar bloque</button>
+    </div>
+  </div>
+<?php endfor; ?>
+</div>
+
+                        </div>
+                      </div>
+                    </div>
+                    <div class="card-footer">
+                      <div class="col-sm-9 offset-sm-3">
+                        <button class="btn btn-primary" type="submit">Crear</button>
+						            <a href="listarAlmacenes.php" class="btn btn-light">Volver</a>
+                      </div>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- Container-fluid Ends-->
+        </div>
+        <!-- footer start-->
+		    <?php include("footer.php"); ?>
+      </div>
+    </div>
+    <!-- latest jquery-->
+    <script src="assets/js/jquery-3.2.1.min.js"></script>
+    <!-- Bootstrap js-->
+    <script src="assets/js/bootstrap/popper.min.js"></script>
+    <script src="assets/js/bootstrap/bootstrap.js"></script>
+    <!-- feather icon js-->
+    <script src="assets/js/icons/feather-icon/feather.min.js"></script>
+    <script src="assets/js/icons/feather-icon/feather-icon.js"></script>
+    <!-- Sidebar jquery-->
+    <script src="assets/js/sidebar-menu.js"></script>
+    <script src="assets/js/config.js"></script>
+    <!-- Plugins JS start-->
+    <script src="assets/js/typeahead/handlebars.js"></script>
+    <script src="assets/js/typeahead/typeahead.bundle.js"></script>
+    <script src="assets/js/typeahead/typeahead.custom.js"></script>
+    <script src="assets/js/chat-menu.js"></script>
+    <script src="assets/js/tooltip-init.js"></script>
+    <script src="assets/js/typeahead-search/handlebars.js"></script>
+    <script src="assets/js/typeahead-search/typeahead-custom.js"></script>
+    <!-- Plugins JS Ends-->
+    <!-- Theme js-->
+    <script src="assets/js/script.js"></script>
+      <!-- Plugin used-->
+            <script src="assets/js/select2/select2.full.min.js"></script>
+      <script src="assets/js/select2/select2-custom.js"></script>
+      <script src="assets/js/horarios_tabs.js"></script>
+      <script>
+        function convertirAMayusculas(input) {
+          input.value = input.value.toUpperCase();
+        }
+      </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add compact new warehouse form with slimmer inline time inputs
- Introduce accordion, tabbed, and table variants of the schedule editor
- Provide dedicated JS helpers for each variant to manage schedule blocks

## Testing
- `php -l admin/nuevoAlmacen_compacto.php admin/nuevoAlmacen_acordeon.php admin/nuevoAlmacen_tabs.php admin/nuevoAlmacen_tabla.php`


------
https://chatgpt.com/codex/tasks/task_e_68be246223388321be9f6a77376e3f14