### PR TITLE
Use Select2 for day selection in new store form

### DIFF
--- a/admin/assets/js/horarios_grupo.js
+++ b/admin/assets/js/horarios_grupo.js
@@ -16,7 +16,7 @@ function addGroup(){
     <div class="form-group row">
       <label class="col-sm-3 col-form-label">Días</label>
       <div class="col-sm-9">
-        <select multiple class="form-control dias-select" name="horarios[${idx}][dias][]">${options}</select>
+        <select multiple class="dias-select" name="horarios[${idx}][dias][]">${options}</select>
       </div>
     </div>
     <div class="blocks"></div>
@@ -24,6 +24,7 @@ function addGroup(){
     <button type="button" class="btn btn-danger btn-sm remove-group">Eliminar grupo</button>
   `;
   container.appendChild(div);
+  $(div).find('.dias-select').select2({width:'100%'});
   addBlock(div);
   updateDisabledDays();
 }
@@ -76,6 +77,7 @@ function updateDisabledDays(){
         opt.disabled = false;
       }
     });
+    $(sel).trigger('change.select2');
   });
 }
 


### PR DESCRIPTION
## Summary
- Enhance dynamically generated day selector by initializing Select2 and removing Bootstrap default styling
- Refresh Select2 widgets when day options are enabled/disabled to prevent duplicate selections

## Testing
- `php -l admin/nuevoAlmacen_v2.php`
- `node --check admin/assets/js/horarios_grupo.js`


------
https://chatgpt.com/codex/tasks/task_e_68bed32964d083218c76ed881b4bbd06