### PR TITLE
Support grouped schedules when modifying almacen

### DIFF
--- a/admin/assets/js/horarios_grupo.js
+++ b/admin/assets/js/horarios_grupo.js
@@ -103,5 +103,13 @@ document.addEventListener('change', function(e){
 });
 
 document.addEventListener('DOMContentLoaded', function(){
-  addGroup();
+  groupCounter = document.querySelectorAll('#groups .group-block').length;
+  if(groupCounter === 0){
+    addGroup();
+  }else{
+    document.querySelectorAll('#groups .group-block').forEach(group=>{
+      $(group).find('.dias-select').select2({width:'100%'});
+    });
+    updateDisabledDays();
+  }
 });


### PR DESCRIPTION
## Summary
- Replace day-based schedule editing with group-based interface
- Use `horarios_grupo.js` for dynamic group/block management
- Validate and store schedules iterating groups and days

## Testing
- `php -l admin/modificarAlmacen.php`
- `node --check admin/assets/js/horarios_grupo.js`


------
https://chatgpt.com/codex/tasks/task_e_68bedc9ce21083218959be642f15748c