### PR TITLE
Filtrar turnos con margen mínimo de 60 minutos

### DIFF
--- a/emitirTurno.php
+++ b/emitirTurno.php
@@ -67,6 +67,27 @@ function turnoDisponible($pdo, $idAlmacen, $fecha, $hora){
     return !isset($bloqueados[$hora]);
 }
 
+$fechaSolicitada = $_POST['fecha'] ?? '';
+$horaSolicitada  = $_POST['hora'] ?? '';
+$hoy = new DateTime('today');
+$limite = new DateTime('+60 minutes');
+
+$fechaDT = DateTime::createFromFormat('Y-m-d', $fechaSolicitada);
+if (!$fechaDT || $fechaDT < $hoy) {
+    Database::disconnect();
+    echo 'La fecha seleccionada no es válida.';
+    exit;
+}
+
+if ($fechaDT->format('Y-m-d') === $hoy->format('Y-m-d')) {
+    $horaDT = DateTime::createFromFormat('H:i', $horaSolicitada);
+    if (!$horaDT || $horaDT < $limite) {
+        Database::disconnect();
+        echo 'La hora debe ser al menos 60 minutos posterior a la actual.';
+        exit;
+    }
+}
+
 $pdo->beginTransaction();
 if(!turnoDisponible($pdo, $_POST['id_almacen'], $_POST['fecha'], $_POST['hora'])){
     $pdo->rollBack();

--- a/obtenerHorarios.php
+++ b/obtenerHorarios.php
@@ -65,10 +65,19 @@ foreach ($reservas as $res) {
 }
 
 $disponibles = [];
+$hoy = date('Y-m-d');
+$limite = new DateTime('+60 minutes');
 foreach ($slots as $slot) {
-    if (!isset($bloqueados[$slot['hora']])) {
-        $disponibles[] = $slot['hora'];
+    if (isset($bloqueados[$slot['hora']])) {
+        continue;
     }
+    if ($fecha === $hoy) {
+        $slotTime = DateTime::createFromFormat('H:i', $slot['hora']);
+        if ($slotTime < $limite) {
+            continue;
+        }
+    }
+    $disponibles[] = $slot['hora'];
 }
 
 Database::disconnect();

--- a/turnos.php
+++ b/turnos.php
@@ -289,8 +289,9 @@ include('admin/database.php');
         var todayStr = new Date().toISOString().split('T')[0];
         if (fecha === todayStr) {
           var now = new Date();
-          var currentTime = ("0" + now.getHours()).slice(-2) + ":" + ("0" + now.getMinutes()).slice(-2);
-          data = data.filter(function (h) { return h >= currentTime; });
+          now.setMinutes(now.getMinutes() + 60);
+          var limitTime = ("0" + now.getHours()).slice(-2) + ":" + ("0" + now.getMinutes()).slice(-2);
+          data = data.filter(function (h) { return h >= limitTime; });
         }
         $hora.empty();
         if (data.length) {


### PR DESCRIPTION
## Summary
- Filtra en la vista los horarios anteriores a una hora desde ahora
- Excluye del endpoint los slots menores a ahora +60 minutos si la fecha es hoy
- Valida en la emisión que la fecha sea vigente y la hora supere en 60 minutos la actual

## Testing
- `php -l turnos.php`
- `php -l obtenerHorarios.php`
- `php -l emitirTurno.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bedce50d988321aa58506da0133c02