### PR TITLE
Format schedule hours without seconds

### DIFF
--- a/admin/listarAlmacenes.php
+++ b/admin/listarAlmacenes.php
@@ -17,7 +17,9 @@ function obtenerHorarios($pdo, $idAlmacen){
         $horarios = [];
         foreach($rows as $r){
                 $dia = $dias[$r['dia_semana']];
-                $horarios[$dia][] = $r['hora_inicio'].'-'.$r['hora_fin'].' ('.$r['frecuencia_minutos'].'m)';
+                $inicio = date('H:i', strtotime($r['hora_inicio']));
+                $fin = date('H:i', strtotime($r['hora_fin']));
+                $horarios[$dia][] = $inicio.'-'.$fin.' ('.$r['frecuencia_minutos'].'m)';
         }
         $partes = [];
         foreach($horarios as $dia => $rangos){


### PR DESCRIPTION
## Summary
- Format `hora_inicio` and `hora_fin` in `listarAlmacenes.php` using `date('H:i', strtotime(...))` to remove seconds from displayed schedule.

## Testing
- `php -l admin/listarAlmacenes.php`
- `php -r 'echo date("H:i", strtotime("09:15:00")) . "-" . date("H:i", strtotime("18:30:45")) . "\n";'`


------
https://chatgpt.com/codex/tasks/task_e_68bedf9f78dc8321a571f059a11056a3