### PR TITLE
Reubicar botón de eliminar grupo en formularios de almacenes

### DIFF
--- a/admin/assets/js/horarios_grupo.js
+++ b/admin/assets/js/horarios_grupo.js
@@ -5,32 +5,39 @@ const diasSemana = ['Lunes','Martes','Miércoles','Jueves','Viernes','Sábado','
 function addGroup(){
   const container = document.getElementById('groups');
   const idx = groupCounter++;
-  const div = document.createElement('div');
-  div.className = 'group-block mb-3 border p-3';
-  div.dataset.index = idx;
+  const row = document.createElement('div');
+  row.className = 'group-row row mb-3';
+
   let options = '';
   for(let i=0;i<diasSemana.length;i++){
     options += `<option value="${i}">${diasSemana[i]}</option>`;
   }
-  div.innerHTML = `
-    <div class="d-flex justify-content-between align-items-center mb-2">
-      <label class="col-form-label mb-0">Días</label>
+
+  row.innerHTML = `
+    <div class="group-block col-sm-11 border p-3" data-index="${idx}">
+      <div class="mb-2">
+        <label class="col-form-label mb-0">Días</label>
+      </div>
+      <div class="form-group">
+        <select multiple class="dias-select" name="horarios[${idx}][dias][]">${options}</select>
+      </div>
+      <div class="blocks"></div>
+      <button type="button" class="btn btn-secondary btn-sm add-block">Agregar bloque</button>
+    </div>
+    <div class="col-sm-1 d-flex align-items-center justify-content-center">
       <button type="button" class="btn btn-danger btn-sm remove-group">Eliminar grupo</button>
     </div>
-    <div class="form-group">
-      <select multiple class="dias-select" name="horarios[${idx}][dias][]">${options}</select>
-    </div>
-    <div class="blocks"></div>
-    <button type="button" class="btn btn-secondary btn-sm add-block">Agregar bloque</button>
   `;
-  container.appendChild(div);
-  $(div).find('.dias-select').select2({width:'100%'});
-  addBlock(div);
+
+  container.appendChild(row);
+  const block = row.querySelector('.group-block');
+  $(block).find('.dias-select').select2({width:'100%'});
+  addBlock(block);
   updateDisabledDays();
 }
 
-function removeGroup(group){
-  group.remove();
+function removeGroup(row){
+  row.remove();
   updateDisabledDays();
 }
 
@@ -86,7 +93,7 @@ document.addEventListener('click', function(e){
     addGroup();
   }
   if(e.target.classList.contains('remove-group')){
-    removeGroup(e.target.closest('.group-block'));
+    removeGroup(e.target.closest('.group-row'));
   }
   if(e.target.classList.contains('add-block')){
     addBlock(e.target.closest('.group-block'));

--- a/admin/modificarAlmacen.php
+++ b/admin/modificarAlmacen.php
@@ -248,35 +248,39 @@ if ( !empty($_POST)) {
   </div>
   <div id="groups">
   <?php foreach($grupos as $i => $g): ?>
-    <div class="group-block mb-3 border p-3" data-index="<?= $i ?>">
-      <div class="d-flex justify-content-between align-items-center mb-2">
-        <label class="col-form-label mb-0">Días</label>
+    <div class="group-row row mb-3">
+      <div class="group-block col-sm-11 border p-3" data-index="<?= $i ?>">
+        <div class="mb-2">
+          <label class="col-form-label mb-0">Días</label>
+        </div>
+        <div class="form-group">
+          <select multiple class="dias-select" name="horarios[<?= $i ?>][dias][]">
+            <?php for($d=0;$d<7;$d++): ?>
+              <option value="<?= $d ?>" <?php if(in_array($d,$g['dias'])) echo 'selected'; ?>><?= $diasSemana[$d] ?></option>
+            <?php endfor; ?>
+          </select>
+        </div>
+        <div class="blocks">
+          <?php foreach($g['inicio'] as $k=>$ini): $fin=$g['fin'][$k] ?? ''; ?>
+          <div class="block form-group row">
+            <span class="block-label col-12">Bloque <?= $k + 1 ?></span>
+            <div class="col-sm-5">
+              <label>Inicio</label>
+              <input type="time" step="300" name="horarios[<?= $i ?>][inicio][]" class="form-control" value="<?= $ini ?>">
+            </div>
+            <div class="col-sm-5">
+              <label>Fin</label>
+              <input type="time" step="300" name="horarios[<?= $i ?>][fin][]" class="form-control" value="<?= $fin ?>">
+            </div>
+            <div class="col-sm-2 d-flex align-items-end"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>
+          </div>
+          <?php endforeach; ?>
+        </div>
+        <button type="button" class="btn btn-secondary btn-sm add-block">Agregar bloque</button>
+      </div>
+      <div class="col-sm-1 d-flex align-items-center justify-content-center">
         <button type="button" class="btn btn-danger btn-sm remove-group">Eliminar grupo</button>
       </div>
-      <div class="form-group">
-        <select multiple class="dias-select" name="horarios[<?= $i ?>][dias][]">
-          <?php for($d=0;$d<7;$d++): ?>
-            <option value="<?= $d ?>" <?php if(in_array($d,$g['dias'])) echo 'selected'; ?>><?= $diasSemana[$d] ?></option>
-          <?php endfor; ?>
-        </select>
-      </div>
-      <div class="blocks">
-        <?php foreach($g['inicio'] as $k=>$ini): $fin=$g['fin'][$k] ?? ''; ?>
-        <div class="block form-group row">
-          <span class="block-label col-12">Bloque <?= $k + 1 ?></span>
-          <div class="col-sm-5">
-            <label>Inicio</label>
-            <input type="time" step="300" name="horarios[<?= $i ?>][inicio][]" class="form-control" value="<?= $ini ?>">
-          </div>
-          <div class="col-sm-5">
-            <label>Fin</label>
-            <input type="time" step="300" name="horarios[<?= $i ?>][fin][]" class="form-control" value="<?= $fin ?>">
-          </div>
-          <div class="col-sm-2 d-flex align-items-end"><button type="button" class="btn btn-danger btn-sm remove-block">X</button></div>
-        </div>
-        <?php endforeach; ?>
-      </div>
-      <button type="button" class="btn btn-secondary btn-sm add-block">Agregar bloque</button>
     </div>
   <?php endforeach; ?>
   </div>


### PR DESCRIPTION
## Summary
- Estructura de grupos de horarios con columna lateral para el botón de eliminación
- Ajuste de plantilla de modificación de almacenes para acomodar el botón exterior

## Testing
- `npm test` *(falla: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bee36d445c8321b025a9e5fbf2e6a3