### PR TITLE
Mejora botón eliminar grupo en horarios de almacén

### DIFF
--- a/admin/assets/js/horarios_grupo.js
+++ b/admin/assets/js/horarios_grupo.js
@@ -14,7 +14,7 @@ function addGroup(){
   }
 
   row.innerHTML = `
-    <div class="group-block col-sm-11 border p-3" data-index="${idx}">
+    <div class="group-block col-sm-10 border p-3" data-index="${idx}">
       <div class="mb-2">
         <label class="col-form-label mb-0">Días</label>
       </div>
@@ -24,8 +24,8 @@ function addGroup(){
       <div class="blocks"></div>
       <button type="button" class="btn btn-secondary btn-sm add-block">Agregar bloque</button>
     </div>
-    <div class="col-sm-1 d-flex align-items-center justify-content-center">
-      <button type="button" class="btn btn-danger btn-sm remove-group">Eliminar grupo</button>
+    <div class="col-sm-2 d-flex align-items-center justify-content-center">
+      <button type="button" class="btn btn-danger btn-sm remove-group" title="Eliminar grupo"><i class="fa fa-trash"></i></button>
     </div>
   `;
 

--- a/admin/modificarAlmacen.php
+++ b/admin/modificarAlmacen.php
@@ -249,7 +249,7 @@ if ( !empty($_POST)) {
   <div id="groups">
   <?php foreach($grupos as $i => $g): ?>
     <div class="group-row row mb-3">
-      <div class="group-block col-sm-11 border p-3" data-index="<?= $i ?>">
+      <div class="group-block col-sm-10 border p-3" data-index="<?= $i ?>">
         <div class="mb-2">
           <label class="col-form-label mb-0">Días</label>
         </div>
@@ -278,8 +278,8 @@ if ( !empty($_POST)) {
         </div>
         <button type="button" class="btn btn-secondary btn-sm add-block">Agregar bloque</button>
       </div>
-      <div class="col-sm-1 d-flex align-items-center justify-content-center">
-        <button type="button" class="btn btn-danger btn-sm remove-group">Eliminar grupo</button>
+      <div class="col-sm-2 d-flex align-items-center justify-content-center">
+        <button type="button" class="btn btn-danger btn-sm remove-group" title="Eliminar grupo"><i class="fa fa-trash"></i></button>
       </div>
     </div>
   <?php endforeach; ?>


### PR DESCRIPTION
## Resumen
- Reduce el ancho del bloque de horarios y amplia el espacio para el botón de eliminación
- Reemplaza el texto del botón por un ícono de basurero para compactarlo

## Testing
- `php -l admin/modificarAlmacen.php`
- `node --check admin/assets/js/horarios_grupo.js`


------
https://chatgpt.com/codex/tasks/task_e_68bee5acd3848321b806aab711a08966