### PR TITLE
Centralizar configuración SMTP y validar datos de formularios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-admin/config.php
 admin/database.php
 admin/BAK
 nueva_web/images/Banners

--- a/admin/config.php
+++ b/admin/config.php
@@ -1,0 +1,10 @@
+<?php
+// SMTP configuration loaded from environment variables with fallbacks
+$smtpHost = getenv('SMTP_HOST') ?: 'c1971287.ferozo.com';
+$smtpPort = getenv('SMTP_PORT') ?: 587;
+$smtpSecure = getenv('SMTP_SECURE') ?: 'tls';
+$smtpUsuario = getenv('SMTP_USER') ?: 'avisos@miroperito.ar';
+$smtpClave = getenv('SMTP_PASS') ?: '';
+$fromEmail = getenv('SMTP_FROM') ?: 'avisos@miroperito.ar';
+$fromName  = getenv('SMTP_FROM_NAME') ?: 'MiRoperito';
+?>

--- a/admin/olvide.php
+++ b/admin/olvide.php
@@ -20,26 +20,28 @@ if(!empty($_POST)){
         $asunto="Recuperación de Contraseña";
         $cuerpo="Recibimos una solicitud para recuperar la contraseña de acceso al sistema de MiRoperito.";
         $envio=enviarMail($destinatarios, $asunto, $cuerpo);
-		$smtpHost = "";  //agregar
-		$smtpUsuario = "";  //agregar
-		$smtpClave = "";  //agregar
-		$mail = new PHPMailer();
-		$mail->IsSMTP();
-		$mail->SMTPAuth = true;
-		$mail->Port = 465; 
-		$mail->SMTPSecure = 'ssl';
-		$mail->IsHTML(true); 
-		$mail->CharSet = "utf-8";
-		$mail->Host = $smtpHost; 
-		$mail->Username = $smtpUsuario; 
-		$mail->Password = $smtpClave;
-		$mail->From = ""; //agregar
-		$mail->FromName = "MiRoperito";
-		$mail->AddAddress($row['email']); 
-		$mail->Subject = $asunto; 
-		$mensajeHtml = nl2br($cuerpo);
-		$mail->Body = "{$mensajeHtml} <br /><br />"; 
-		$mail->AltBody = "{$cuerpo} \n\n"; 
+                if (!filter_var($row['email'], FILTER_VALIDATE_EMAIL)) {
+                    Database::disconnect();
+                    die('Email inválido');
+                }
+                $mail = new PHPMailer();
+                $mail->IsSMTP();
+                $mail->SMTPAuth = true;
+                if($smtpSecure!=""){ $mail->SMTPSecure = $smtpSecure; }
+                $mail->Port = $smtpPort;
+                $mail->IsHTML(true);
+                $mail->CharSet = "utf-8";
+                $mail->Host = $smtpHost;
+                $mail->Username = $smtpUsuario;
+                $mail->Password = $smtpClave;
+                $mail->From = $fromEmail;
+                $mail->FromName = $fromName;
+                $mail->AddReplyTo($row['email'], $row['nombre'] ?? '');
+                $mail->AddAddress($row['email']);
+                $mail->Subject = $asunto;
+                $mensajeHtml = nl2br($cuerpo);
+                $mail->Body = "{$mensajeHtml} <br /><br />";
+                $mail->AltBody = "{$cuerpo} \n\n";
 			
 		//$mail->Send(); descomentar
         

--- a/emitirTurno.php
+++ b/emitirTurno.php
@@ -74,8 +74,16 @@ function turnoDisponible($pdo, $idAlmacen, $fecha, $hora){
     return !isset($bloqueados[$hora]);
 }
 
-$fechaSolicitada = $_POST['fecha'] ?? '';
-$horaSolicitada  = $_POST['hora'] ?? '';
+$fecha = $_POST['fecha'] ?? '';
+$hora  = $_POST['hora'] ?? '';
+$fechaSolicitada = $fecha;
+$horaSolicitada  = $hora;
+$idAlmacen = $_POST['id_almacen'] ?? '';
+$cantidad = $_POST['cantidad'] ?? '';
+$dni      = $_POST['dni'] ?? '';
+$nombre   = $_POST['nombre'] ?? '';
+$email    = $_POST['email'] ?? '';
+$telefono = $_POST['telefono'] ?? '';
 $hoy = new DateTime('today');
 $limite = new DateTime('+60 minutes');
 
@@ -93,8 +101,16 @@ if ($fechaDT->format('Y-m-d') === $hoy->format('Y-m-d')) {
     }
 }
 
+$errorDatos = (!filter_var($email, FILTER_VALIDATE_EMAIL) ||
+               strlen($nombre) > 100 || strlen($dni) > 20 || strlen($telefono) > 20 ||
+               $nombre !== strip_tags($nombre) || $dni !== strip_tags($dni) || $telefono !== strip_tags($telefono));
+if ($errorDatos) {
+    Database::disconnect();
+    jsonResponse(false, 'Datos inválidos');
+}
+
 $pdo->beginTransaction();
-if(!turnoDisponible($pdo, $_POST['id_almacen'], $_POST['fecha'], $_POST['hora'])){
+if(!turnoDisponible($pdo, $idAlmacen, $fecha, $hora)){
     $pdo->rollBack();
     Database::disconnect();
     jsonResponse(false, 'Horario ocupado');
@@ -103,7 +119,7 @@ if(!turnoDisponible($pdo, $_POST['id_almacen'], $_POST['fecha'], $_POST['hora'])
 $sql = 'INSERT INTO `turnos`(`fecha_hora`,`id_almacen`, `cantidad`, `fecha`, `hora`, `dni`, `nombre`, `email`, `telefono`, `id_estado`) VALUES (now(),?,?,?,?,?,?,?,?,1)';
 $q = $pdo->prepare($sql);
 try {
-    $q->execute([$_POST['id_almacen'],$_POST['cantidad'],$_POST['fecha'],$_POST['hora'],$_POST['dni'],$_POST['nombre'],$_POST['email'],$_POST['telefono']]);
+    $q->execute([$idAlmacen,$cantidad,$fecha,$hora,$dni,$nombre,$email,$telefono]);
     $pdo->commit();
 } catch (PDOException $e) {
     $pdo->rollBack();
@@ -123,13 +139,6 @@ try {
 
 	//$sucursal =$_POST['id_almacen'];
   $sucursal =$almacen;
-	$cantidad =$_POST['cantidad'];
-	$fecha =$_POST['fecha'];
-	$hora =$_POST['hora'];
-	$nombre =$_POST["nombre"];
-	$email =$_POST["email"];
-	$telefono=$_POST["telefono"];
-	$dni = $_POST["dni"];
 	
 	$message = "
 	<html>
@@ -184,14 +193,12 @@ try {
 
   //SELECT * FROM `turnos` WHERE DATE(fecha_hora)>="2023-03-02" AND fecha_hora<"2023-03-28 16:01";
 	
-	//$smtpHost = "c1971287.ferozo.com";
+        //$smtpHost = "c1971287.ferozo.com";
   //$smtpHost = "miroperito.ar";
   //$smtpHost = "tecnosoul.com.ar";
-	$smtpUsuario = "avisos@miroperito.ar";
-	$smtpClave = "zR*eHJJ3zK";
-	$mail = new PHPMailer();
-	$mail->IsSMTP();
-	$mail->SMTPAuth = true;
+        $mail = new PHPMailer();
+        $mail->IsSMTP();
+        $mail->SMTPAuth = true;
   if($email=="axelbritzius@gmail.com"){
     $mail->SMTPDebug = 3;
   }
@@ -205,13 +212,14 @@ try {
 
 	$mail->IsHTML(true); 
 	$mail->CharSet = "utf-8";
-	$mail->Host = $smtpHost; 
-	$mail->Username = $smtpUsuario; 
-	$mail->Password = $smtpClave;
-	$mail->From = $email;
-	$mail->FromName = $nombre;
-	$mail->AddAddress("vende@miroperito.ar");
-	$mail->AddAddress($email);
+        $mail->Host = $smtpHost;
+        $mail->Username = $smtpUsuario;
+        $mail->Password = $smtpClave;
+        $mail->From = $fromEmail;
+        $mail->FromName = $fromName;
+        $mail->AddReplyTo($email, $nombre);
+        $mail->AddAddress("vende@miroperito.ar");
+        $mail->AddAddress($email);
 	$mensaje = $message;
 	$mail->Subject = "Solicitud de Turno MiRoperito"; 
 	$mensajeHtml = nl2br($mensaje);

--- a/nueva_web/emitirTurno.php
+++ b/nueva_web/emitirTurno.php
@@ -74,8 +74,16 @@ function turnoDisponible($pdo, $idAlmacen, $fecha, $hora){
     return !isset($bloqueados[$hora]);
 }
 
-$fechaSolicitada = $_POST['fecha'] ?? '';
-$horaSolicitada  = $_POST['hora'] ?? '';
+$fecha = $_POST['fecha'] ?? '';
+$hora  = $_POST['hora'] ?? '';
+$fechaSolicitada = $fecha;
+$horaSolicitada  = $hora;
+$idAlmacen = $_POST['id_almacen'] ?? '';
+$cantidad = $_POST['cantidad'] ?? '';
+$dni      = $_POST['dni'] ?? '';
+$nombre   = $_POST['nombre'] ?? '';
+$email    = $_POST['email'] ?? '';
+$telefono = $_POST['telefono'] ?? '';
 $hoy = new DateTime('today');
 $limite = new DateTime('+60 minutes');
 
@@ -93,8 +101,16 @@ if ($fechaDT->format('Y-m-d') === $hoy->format('Y-m-d')) {
     }
 }
 
+$errorDatos = (!filter_var($email, FILTER_VALIDATE_EMAIL) ||
+               strlen($nombre) > 100 || strlen($dni) > 20 || strlen($telefono) > 20 ||
+               $nombre !== strip_tags($nombre) || $dni !== strip_tags($dni) || $telefono !== strip_tags($telefono));
+if ($errorDatos) {
+    Database::disconnect();
+    jsonResponse(false, 'Datos inválidos');
+}
+
 $pdo->beginTransaction();
-if(!turnoDisponible($pdo, $_POST['id_almacen'], $_POST['fecha'], $_POST['hora'])){
+if(!turnoDisponible($pdo, $idAlmacen, $fecha, $hora)){
     $pdo->rollBack();
     Database::disconnect();
     jsonResponse(false, 'Horario ocupado');
@@ -103,7 +119,7 @@ if(!turnoDisponible($pdo, $_POST['id_almacen'], $_POST['fecha'], $_POST['hora'])
 $sql = 'INSERT INTO `turnos`(`fecha_hora`,`id_almacen`, `cantidad`, `fecha`, `hora`, `dni`, `nombre`, `email`, `telefono`, `id_estado`) VALUES (now(),?,?,?,?,?,?,?,?,1)';
 $q = $pdo->prepare($sql);
 try {
-    $q->execute([$_POST['id_almacen'],$_POST['cantidad'],$_POST['fecha'],$_POST['hora'],$_POST['dni'],$_POST['nombre'],$_POST['email'],$_POST['telefono']]);
+    $q->execute([$idAlmacen,$cantidad,$fecha,$hora,$dni,$nombre,$email,$telefono]);
     $pdo->commit();
 } catch (PDOException $e) {
     $pdo->rollBack();
@@ -123,13 +139,6 @@ try {
 
 	//$sucursal =$_POST['id_almacen'];
   $sucursal =$almacen;
-	$cantidad =$_POST['cantidad'];
-	$fecha =$_POST['fecha'];
-	$hora =$_POST['hora'];
-	$nombre =$_POST["nombre"];
-	$email =$_POST["email"];
-	$telefono=$_POST["telefono"];
-	$dni = $_POST["dni"];
 	
 	$message = "
 	<html>
@@ -184,14 +193,12 @@ try {
 
   //SELECT * FROM `turnos` WHERE DATE(fecha_hora)>="2023-03-02" AND fecha_hora<"2023-03-28 16:01";
 	
-	//$smtpHost = "c1971287.ferozo.com";
+        //$smtpHost = "c1971287.ferozo.com";
   //$smtpHost = "miroperito.ar";
   //$smtpHost = "tecnosoul.com.ar";
-	$smtpUsuario = "avisos@miroperito.ar";
-	$smtpClave = "zR*eHJJ3zK";
-	$mail = new PHPMailer();
-	$mail->IsSMTP();
-	$mail->SMTPAuth = true;
+        $mail = new PHPMailer();
+        $mail->IsSMTP();
+        $mail->SMTPAuth = true;
   if($email=="axelbritzius@gmail.com"){
     $mail->SMTPDebug = 3;
   }
@@ -205,13 +212,14 @@ try {
 
 	$mail->IsHTML(true); 
 	$mail->CharSet = "utf-8";
-	$mail->Host = $smtpHost; 
-	$mail->Username = $smtpUsuario; 
-	$mail->Password = $smtpClave;
-	$mail->From = $email;
-	$mail->FromName = $nombre;
-	$mail->AddAddress("vende@miroperito.ar");
-	$mail->AddAddress($email);
+        $mail->Host = $smtpHost;
+        $mail->Username = $smtpUsuario;
+        $mail->Password = $smtpClave;
+        $mail->From = $fromEmail;
+        $mail->FromName = $fromName;
+        $mail->AddReplyTo($email, $nombre);
+        $mail->AddAddress("vende@miroperito.ar");
+        $mail->AddAddress($email);
 	$mensaje = $message;
 	$mail->Subject = "Solicitud de Turno MiRoperito"; 
 	$mensajeHtml = nl2br($mensaje);

--- a/probarEnvioMail.php
+++ b/probarEnvioMail.php
@@ -56,14 +56,12 @@
 	</html>
 	";
 	
-	//$smtpHost = "c1971287.ferozo.com";
+        //$smtpHost = "c1971287.ferozo.com";
   //$smtpHost = "mail.miroperito.ar";
-	$smtpUsuario = "avisos@miroperito.ar";
-	$smtpClave = "zR*eHJJ3zK";
 
-	$mail = new PHPMailer();
-	$mail->IsSMTP();
-	$mail->SMTPAuth = true;
+        $mail = new PHPMailer();
+        $mail->IsSMTP();
+        $mail->SMTPAuth = true;
   $mail->SMTPDebug = 3;
   //$mail->SMTPDebug = SMTP::DEBUG_CLIENT;
 	
@@ -80,12 +78,13 @@
 	
   $mail->IsHTML(true); 
 	$mail->CharSet = "utf-8";
-	$mail->Host = $smtpHost; 
-	$mail->Username = $smtpUsuario; 
-	$mail->Password = $smtpClave;
-	$mail->From = "axelbritzius@gmail.com";
-	$mail->FromName = "Axel Britzius";
-	$mail->AddAddress("axelbritzius@gmail.com");
+        $mail->Host = $smtpHost;
+        $mail->Username = $smtpUsuario;
+        $mail->Password = $smtpClave;
+        $mail->From = $fromEmail;
+        $mail->FromName = $fromName;
+        $mail->AddReplyTo("axelbritzius@gmail.com", "Axel Britzius");
+        $mail->AddAddress("axelbritzius@gmail.com");
 	$mensaje = $message;
 	$mail->Subject = "Solicitud de Turno MiRoperito"; 
 	$mensajeHtml = nl2br($mensaje);


### PR DESCRIPTION
## Summary
- Centraliza credenciales y parámetros SMTP en `admin/config.php` con soporte de variables de entorno
- Fija remitente de correo y utiliza `AddReplyTo` con el email del usuario
- Añade validaciones básicas de email, longitud y HTML antes de enviar mensajes

## Testing
- `php -l admin/config.php`
- `php -l contactar.php`
- `php -l emitirTurno.php`
- `php -l nueva_web/emitirTurno.php`
- `php -l admin/olvide.php`
- `php -l probarEnvioMail.php`


------
https://chatgpt.com/codex/tasks/task_e_68c069dacdb483218b8a68e86c767dbd