### PR TITLE
Fix admin path references at project root

### DIFF
--- a/btn-convenio.php
+++ b/btn-convenio.php
@@ -1,7 +1,7 @@
 <section class="container btn-convenio">
 	<div>
 		<?php 
-		include '../admin/database.php';
+		include 'admin/database.php';
 		$pdo = Database::connect();
 		$id = 9;
   		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -12,8 +12,8 @@
 
 		Database::disconnect();
 		?>
-		<a href="../admin/files/<?=$data["valor"];?>" target="_blank">Ver convenio</a>
+		<a href="admin/files/<?=$data["valor"];?>" target="_blank">Ver convenio</a>
 		<a href="turnos.php" class="segundo-enlace">Sacar turno para vender</a>
-		<a href="../admin/loginProveedores.php" target="_blank">Ver el estado de mis ventas</a>
+		<a href="admin/loginProveedores.php" target="_blank">Ver el estado de mis ventas</a>
 	</div>
 </section>

--- a/emitirTurno.php
+++ b/emitirTurno.php
@@ -1,9 +1,9 @@
 <?php
-require('../admin/config.php');
-require('../admin/database.php');
+require('admin/config.php');
+require('admin/database.php');
 
-require('../admin/PHPMailer/class.phpmailer.php');
-require('../admin/PHPMailer/class.smtp.php');
+require('admin/PHPMailer/class.phpmailer.php');
+require('admin/PHPMailer/class.smtp.php');
 
 header('Content-Type: application/json');
 

--- a/footer.php
+++ b/footer.php
@@ -23,7 +23,7 @@
 						<ul class="tt-list">
 							<li><a href="terminos-condiciones.php" class="text-uppercase footer-enlaces">Términos y Condiciones</a></li>
 							<li><a href="preguntas-frecuentes.php" class="text-uppercase footer-enlaces">Preguntas Frecuentes</a></li>
-							<li><a href="../admin/loginProveedores.php" class="text-uppercase footer-enlaces">Mi Cuenta</a></li>
+							<li><a href="admin/loginProveedores.php" class="text-uppercase footer-enlaces">Mi Cuenta</a></li>
 							<li><a href="locales.php" class="text-uppercase footer-enlaces">Locales</a></li>
 							<li><a href="contacto.php" class="text-uppercase footer-enlaces">Contacto</a></li>
 							

--- a/header.php
+++ b/header.php
@@ -112,7 +112,7 @@
 								</div>
 								<div class="tt-dropdown-inner">
 									<ul>
-									<li><a target="_blank" href="../admin/loginProveedores.php"><i class="icon-f-76"></i>Ingresar</a></li>
+									<li><a target="_blank" href="admin/loginProveedores.php"><i class="icon-f-76"></i>Ingresar</a></li>
 									</ul>
 								</div>
 							</div>

--- a/suscribir.php
+++ b/suscribir.php
@@ -1,6 +1,6 @@
 <?php 
-    require("../admin/config.php");
-	require("../admin/database.php");
+    require("admin/config.php");
+	require("admin/database.php");
     
 	$pdo = Database::connect();
 	$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/testimonios.php
+++ b/testimonios.php
@@ -14,7 +14,7 @@
 				
 				<div class="col-sm-12 contenedor-carrusel">
 					<div id="testimonial-slider" class="owl-carousel carrusel"><?php
-						include '../admin/database.php';
+						include 'admin/database.php';
 						$pdo = Database::connect();
 						$sql = "SELECT id, seccion,`url-jpg`, activo FROM banners WHERE activo = 1 AND seccion = 1"; 
 

--- a/turnos.php
+++ b/turnos.php
@@ -1,6 +1,6 @@
 <?php
-require("../admin/config.php");
-include('../admin/database.php');
+require("admin/config.php");
+include('admin/database.php');
 ?>
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## Summary
- Use `admin/` rather than `../admin` for includes and links in root-level pages
- Update provider login links to point at `admin/loginProveedores.php`

## Testing
- `php -l btn-convenio.php emitirTurno.php footer.php header.php suscribir.php testimonios.php turnos.php`

------
https://chatgpt.com/codex/tasks/task_e_68c09e8582b883218fde6922825359a7