### PR TITLE
Fix subscription script redirect

### DIFF
--- a/suscribir.php
+++ b/suscribir.php
@@ -1,20 +1,21 @@
-<?php 
-    require("admin/config.php");
-	require("admin/database.php");
-    
-	$pdo = Database::connect();
-	$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-	
-	$sql = "SELECT `id` from suscripciones where email = ?";
-	$q = $pdo->prepare($sql);
-	$q->execute(array($_POST['email']));
-	$data = $q->fetch(PDO::FETCH_ASSOC);
-	if (empty($data)) {
-		$sql = "INSERT INTO `suscripciones`(`email`, `fecha_hora`) VALUES (?,now())";
-		$q = $pdo->prepare($sql);
-		$q->execute(array($_POST['email']));
+<?php
+require("admin/config.php");
+require("admin/database.php");
 
-		Database::disconnect();		
-	}
-	header("Location: ../nueva_web/index.php");
+$pdo = Database::connect();
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$sql = "SELECT `id` from suscripciones where email = ?";
+$q = $pdo->prepare($sql);
+$q->execute(array($_POST['email']));
+$data = $q->fetch(PDO::FETCH_ASSOC);
+if (empty($data)) {
+    $sql = "INSERT INTO `suscripciones`(`email`, `fecha_hora`) VALUES (?,now())";
+    $q = $pdo->prepare($sql);
+    $q->execute(array($_POST['email']));
+
+    Database::disconnect();
+}
+header("Location: index.php");
 ?>
+


### PR DESCRIPTION
## Summary
- ensure suscribir.php loads config and database classes from admin
- redirect subscription handler back to index.php

## Testing
- `php -l suscribir.php`
- `php -r '$_POST["email"]="test@example.com"; include "suscribir.php";'` *(fails: Failed opening required 'admin/database.php')*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a0503ac0832192dc7369d71904fa