### PR TITLE
Adjust horario endpoint and AJAX path

### DIFF
--- a/obtenerHorarios.php
+++ b/obtenerHorarios.php
@@ -1,0 +1,85 @@
+<?php
+require __DIR__ . '/admin/config.php';
+require __DIR__ . '/admin/database.php';
+
+header('Content-Type: application/json');
+
+$idAlmacen = isset($_GET['id_almacen']) ? (int)$_GET['id_almacen'] : 0;
+$fecha     = $_GET['fecha'] ?? '';
+if(!$idAlmacen || !$fecha){
+    echo json_encode([]);
+    exit;
+}
+
+$diaSemana = (int)date('N', strtotime($fecha)) - 1; // 0=Lunes ... 6=Domingo
+
+$pdo = Database::connect();
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$sqlFranjas = "SELECT hora_inicio,hora_fin,frecuencia_minutos,bloqueo_minutos
+               FROM almacenes_horarios
+               WHERE id_almacen = ? AND dia_semana = ?
+               ORDER BY hora_inicio";
+$q = $pdo->prepare($sqlFranjas);
+$q->execute([$idAlmacen,$diaSemana]);
+$franjas = $q->fetchAll(PDO::FETCH_ASSOC);
+
+$slots = [];
+foreach ($franjas as $franja) {
+    $inicio = new DateTime($franja['hora_inicio']);
+    $fin    = new DateTime($franja['hora_fin']);
+    $freq   = (int)$franja['frecuencia_minutos'];
+    $bloq   = (int)$franja['bloqueo_minutos'];
+    for ($t = clone $inicio; $t < $fin; $t->modify("+{$freq} minutes")) {
+        $slots[] = ['hora' => $t->format('H:i'), 'bloqueo' => $bloq, 'frecuencia' => $freq];
+    }
+}
+
+$sqlTurnos = "SELECT hora FROM turnos WHERE id_almacen = ? AND fecha = ? AND id_estado = 1";
+$q = $pdo->prepare($sqlTurnos);
+$q->execute([$idAlmacen,$fecha]);
+$reservas = $q->fetchAll(PDO::FETCH_COLUMN);
+
+$bloqueados = [];
+foreach ($reservas as $res) {
+    $r = new DateTime($res);
+    $bloqueados[$r->format('H:i')] = true;
+    // buscar franja correspondiente para obtener parametros
+    foreach ($franjas as $franja) {
+        $inicioFr = new DateTime($franja['hora_inicio']);
+        $finFr    = new DateTime($franja['hora_fin']);
+        if ($r >= $inicioFr && $r < $finFr) {
+            $freq = (int)$franja['frecuencia_minutos'];
+            $bloq = (int)$franja['bloqueo_minutos'];
+            $inicioBloq = (clone $r)->modify("-{$bloq} minutes");
+            $finBloq    = (clone $r)->modify("+{$bloq} minutes");
+            for ($t = clone $r; $t < $finBloq; $t->modify("+{$freq} minutes")) {
+                $bloqueados[$t->format('H:i')] = true;
+            }
+            for ($t = clone $r; $t > $inicioBloq; $t->modify("-{$freq} minutes")) {
+                $bloqueados[$t->format('H:i')] = true;
+            }
+            break;
+        }
+    }
+}
+
+$disponibles = [];
+$hoy = date('Y-m-d');
+$limite = new DateTime('+60 minutes');
+foreach ($slots as $slot) {
+    if (isset($bloqueados[$slot['hora']])) {
+        continue;
+    }
+    if ($fecha === $hoy) {
+        $slotTime = DateTime::createFromFormat('H:i', $slot['hora']);
+        if ($slotTime < $limite) {
+            continue;
+        }
+    }
+    $disponibles[] = $slot['hora'];
+}
+
+Database::disconnect();
+
+echo json_encode($disponibles);

--- a/turnos.php
+++ b/turnos.php
@@ -252,7 +252,7 @@ include('admin/database.php');
           $submit.prop('disabled', true);
           return;
         }
-        $.getJSON('../obtenerHorarios.php', { id_almacen: idAlmacen, fecha: fecha }, function (data) {
+        $.getJSON('obtenerHorarios.php', { id_almacen: idAlmacen, fecha: fecha }, function (data) {
           var todayStr = new Date().toISOString().split('T')[0];
           if (fecha === todayStr) {
             var now = new Date();


### PR DESCRIPTION
## Summary
- copy horario availability endpoint to project root with updated config/database includes
- update turn request page to call new obtenerHorarios.php location

## Testing
- `php -l obtenerHorarios.php`
- `php -l turnos.php`
- `php -r '$_GET["id_almacen"]=1; $_GET["fecha"]="2024-05-20"; include "obtenerHorarios.php";'`


------
https://chatgpt.com/codex/tasks/task_e_68c15c00e33483219f6bd293d491d6dc