### PR TITLE
chore: update image paths in admin

### DIFF
--- a/admin/dashboardProveedor.php
+++ b/admin/dashboardProveedor.php
@@ -56,7 +56,7 @@ require 'database.php';?>
                     foreach ($pdo->query($sql) as $row) {
                       echo '<div class="swiper-slide">';	
                       echo '<picture>';
-                      echo '<img loading="lazy" decoding="async" src="../nueva_web/images/Banners/Proveedores/' . $row['url-jpg'] . '" alt="imagen" width="100%" height="100%">';
+                      echo '<img loading="lazy" decoding="async" src="../images/Banners/Proveedores/' . $row['url-jpg'] . '" alt="imagen" width="100%" height="100%">';
                       echo '</picture>';
                       echo '</div>';
                     }
@@ -79,7 +79,7 @@ require 'database.php';?>
                   <div class="row">
                     <div class="col-md-3"></div>
                     <div class="col-md-6">
-                      <img src="../nueva_web/images/Banners/Proveedores/dashboardProveedor.jpeg" alt="Imagen Dashboard Proveedor" class="img-fluid">
+                      <img src="../images/Banners/Proveedores/dashboardProveedor.jpeg" alt="Imagen Dashboard Proveedor" class="img-fluid">
                     </div>
                     <div class="col-md-3"></div>
                   </div>

--- a/admin/eliminarBanner.php
+++ b/admin/eliminarBanner.php
@@ -35,7 +35,7 @@
 			$seccion = "Proveedores";
 		}
 		// Construir la ruta completa de la imagen
-		$ruta_imagen = '../nueva_web/images/Banners/'. $seccion . '/' . $imagen_nombre;
+		$ruta_imagen = '../images/Banners/'. $seccion . '/' . $imagen_nombre;
 
 		// Verificar si la imagen existe en el sistema de archivos y eliminarla
 		if (file_exists($ruta_imagen)) {

--- a/admin/listarBanners.php
+++ b/admin/listarBanners.php
@@ -237,7 +237,7 @@ if(empty($_SESSION['user'])) {
               var $modalImagen = $('#modalImagen' + modalID.substring(11));
 
              
-              var rutaBase = seccion === 1 ? '../nueva_web/images/Banners/Home/' : '../nueva_web/images/Banners/Proveedores/';
+              var rutaBase = seccion === 1 ? '../images/Banners/Home/' : '../images/Banners/Proveedores/';
 
               var imagenCompletaURL = rutaBase + imagenURL;
 

--- a/admin/login.php
+++ b/admin/login.php
@@ -87,7 +87,7 @@
             <div class="col-md-12">
               <div class="auth-innerright">
                 <div class="authentication-box">
-                  <div class="text-center"><img src="../nueva_web/images/logo/logo-nuevom.png" width="350px" alt=""></div>
+                  <div class="text-center"><img src="../images/logo/logo-nuevom.png" width="350px" alt=""></div>
                   <div class="card mt-4">
                     <div class="card-body">
                       <div class="text-center">

--- a/admin/loginProveedores.php
+++ b/admin/loginProveedores.php
@@ -84,7 +84,7 @@ if(!empty($_POST)){
             <div class="col-md-12">
               <div class="auth-innerright">
                 <div class="authentication-box">
-                  <div class="text-center"><img src="../nueva_web/images/logo/logo-nuevom.png" width="350px" alt=""></div>
+                  <div class="text-center"><img src="../images/logo/logo-nuevom.png" width="350px" alt=""></div>
                   <div class="card mt-4">
                     <div class="card-body">
                       <div class="text-center">

--- a/admin/modificarBanner.php
+++ b/admin/modificarBanner.php
@@ -46,8 +46,8 @@ if (!empty($_POST)) {
 
     if ($seccion != $seccionActual) {
       // Mueve la imagen de la carpeta de la sección actual a la nueva sección
-      $rutaImagenActual = '../nueva_web/images/Banners/' . $seccionActual . '/' . $nombreArchivoJPGActual;
-      $rutaImagenNueva = '../nueva_web/images/Banners/' . $seccion . '/' . $nombreArchivoJPGActual;
+      $rutaImagenActual = '../images/Banners/' . $seccionActual . '/' . $nombreArchivoJPGActual;
+      $rutaImagenNueva = '../images/Banners/' . $seccion . '/' . $nombreArchivoJPGActual;
 
       if (file_exists($rutaImagenActual)) {
         rename($rutaImagenActual, $rutaImagenNueva);
@@ -57,7 +57,7 @@ if (!empty($_POST)) {
 
   // Verifica si se ha enviado una nueva imagen
   if (isset($_FILES['imagen-banner-jpg']) && $_FILES['imagen-banner-jpg']['error'] === UPLOAD_ERR_OK) {
-      $carpetaDestino = '../nueva_web/images/Banners/' . $seccion;
+      $carpetaDestino = '../images/Banners/' . $seccion;
       $nombreArchivoJPG = uniqid() . '-' . $_FILES['imagen-banner-jpg']['name'];
 
       if (move_uploaded_file($_FILES['imagen-banner-jpg']['tmp_name'], $carpetaDestino . '/' . $nombreArchivoJPG)) {
@@ -152,7 +152,7 @@ if (!empty($_POST)) {
                                     $seccion = "Proveedores";
                                 }?>
 
-                                <img src="../nueva_web/images/Banners/<?= $seccion ?>/<?= $data['url-jpg'] ?>" alt="Imagen Banner" style="display: block; max-width: 200px; max-height: 250px; object-fit: cover;">
+                                <img src="../images/Banners/<?= $seccion ?>/<?= $data['url-jpg'] ?>" alt="Imagen Banner" style="display: block; max-width: 200px; max-height: 250px; object-fit: cover;">
                       
                                 <label style="display: block; margin-top: 10px;"><?= $data['url-jpg']; ?></label>
                             </div>

--- a/admin/nuevoBanner.php
+++ b/admin/nuevoBanner.php
@@ -17,7 +17,7 @@ if ( !empty($_POST)) {
 
   //Subir el archivo JPG
   if (isset($_FILES['imagen-banner-jpg']) && $_FILES['imagen-banner-jpg']['error'] === UPLOAD_ERR_OK) {
-    $carpetaDestino = '../nueva_web/images/Banners/' . $seccion;
+    $carpetaDestino = '../images/Banners/' . $seccion;
     $nombreArchivoJPG = uniqid() . '-' . $_FILES['imagen-banner-jpg']['name'];
 
     if (move_uploaded_file($_FILES['imagen-banner-jpg']['tmp_name'], $carpetaDestino . $nombreArchivoJPG)) {


### PR DESCRIPTION
## Summary
- point admin scripts to images/ instead of nueva_web/images
- ensure banner and logo references use updated paths

## Testing
- `php -l admin/login.php`
- `php -l admin/loginProveedores.php`
- `php -l admin/nuevoBanner.php`
- `php -l admin/modificarBanner.php`
- `php -l admin/eliminarBanner.php`
- `php -l admin/dashboardProveedor.php`
- `php -l admin/listarBanners.php`
- `curl -I http://127.0.0.1:8000/images/logo/logo-nuevom.png`
- `curl -I http://127.0.0.1:8000/images/Banners/Proveedores/dashboardProveedor.jpeg`


------
https://chatgpt.com/codex/tasks/task_e_68c15c39463483219f9fd205928a7350