### PR TITLE
Corrige rutas relativas en scripts compartidos

### DIFF
--- a/scripts.php
+++ b/scripts.php
@@ -1,10 +1,10 @@
 <script src="js/img.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script src="../external/jquery/jquery.min.js"><\/script>')</script>
+<script>window.jQuery || document.write('<script src="external/jquery/jquery.min.js"><\/script>')</script>
 <script defer src="js/bundle.js"></script>
 
-<script defer src="../separate-include/single-product/single-product.js"></script>
-<script src="../separate-include/portfolio/portfolio.js"></script>
+<script defer src="separate-include/single-product/single-product.js"></script>
+<script src="separate-include/portfolio/portfolio.js"></script>
 
 <script type="text/javascript" src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/owl-carousel/1.3.3/owl.carousel.min.js"></script>


### PR DESCRIPTION
## Resumen
- Ajusta `scripts.php` para cargar dependencias desde `external/` y `separate-include/` sin prefijo `../`.

## Pruebas
- `php -l scripts.php`
- `curl -I http://127.0.0.1:8000/external/jquery/jquery.min.js`
- `curl -I http://127.0.0.1:8000/separate-include/single-product/single-product.js`
- `curl -I http://127.0.0.1:8000/separate-include/portfolio/portfolio.js`
- `curl -I http://127.0.0.1:8000/css/style.css`
- `curl -I http://127.0.0.1:8000/css/style-skin-lifestyle.css`


------
https://chatgpt.com/codex/tasks/task_e_68c15c4c1a4c83218b0332c10f0155a7