### PR TITLE
Add sanitized contact form handler with SMTP config

### DIFF
--- a/contactar.php
+++ b/contactar.php
@@ -1,0 +1,91 @@
+<?php 
+    require_once __DIR__ . "/admin/config.php";
+    require_once __DIR__ . "/admin/database.php";
+
+    require_once __DIR__ . "/admin/PHPMailer/class.phpmailer.php";
+    require_once __DIR__ . "/admin/PHPMailer/class.smtp.php";
+
+    $nombre  = trim($_POST["nombre"] ?? '');
+    $email   = trim($_POST["email"] ?? '');
+    $mensaje = trim($_POST["mensaje"] ?? '');
+    $subject = trim($_POST["asunto"] ?? '');
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL) ||
+        strlen($nombre) > 100 || strlen($subject) > 150 || strlen($mensaje) > 1000 ||
+        $nombre !== strip_tags($nombre) || $subject !== strip_tags($subject) || $mensaje !== strip_tags($mensaje)) {
+        header("Location: index.php");
+        exit;
+    }
+
+    $pdo = Database::connect();
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $sql = "INSERT INTO `contactos`(`fecha_hora`, `nombre`, `email`, `asunto`, `mensaje`) VALUES (now(),?,?,?,?)";
+    $q = $pdo->prepare($sql);
+    $q->execute(array($nombre,$email,$subject,$mensaje));
+	
+	$message = "
+	<html>
+	<head>
+	<title>Contacto MiRoperito</title>
+	</head>
+	<body>
+	<table width='50%' border='0' align='center' cellpadding='0' cellspacing='0'>
+	<tr>
+	<td colspan='2' align='center' valign='top'><img style=' margin-top: 15px; ' src='https://miroperito.ar/images/logo/Logo-Mi-roperito.png' ></td>
+	</tr>
+	<tr>
+	<td width='50%' align='right'>&nbsp;</td>
+	<td align='left'>&nbsp;</td>
+	</tr>
+	<tr>
+	<td align='right' valign='top' style='border-top:1px solid #dfdfdf; font-family:Arial, Helvetica, sans-serif; font-size:13px; color:#000; padding:7px 5px 7px 0;'>Nombre:</td>
+	<td align='left' valign='top' style='border-top:1px solid #dfdfdf; font-family:Arial, Helvetica, sans-serif; font-size:13px; color:#000; padding:7px 0 7px 5px;'>".$nombre."</td>
+	</tr>
+	<tr>
+	<td align='right' valign='top' style='border-top:1px solid #dfdfdf; font-family:Arial, Helvetica, sans-serif; font-size:13px; color:#000; padding:7px 5px 7px 0;'>Email:</td>
+	<td align='left' valign='top' style='border-top:1px solid #dfdfdf; font-family:Arial, Helvetica, sans-serif; font-size:13px; color:#000; padding:7px 0 7px 5px;'>".$email."</td>
+	</tr>
+	<tr>
+	<td align='right' valign='top' style='border-top:1px solid #dfdfdf; font-family:Arial, Helvetica, sans-serif; font-size:13px; color:#000; padding:7px 5px 7px 0;'>Asunto:</td>
+	<td align='left' valign='top' style='border-top:1px solid #dfdfdf; font-family:Arial, Helvetica, sans-serif; font-size:13px; color:#000; padding:7px 0 7px 5px;'>".$subject."</td>
+	</tr>
+	<tr>
+	<td align='right' valign='top' style='border-top:1px solid #dfdfdf; border-bottom:1px solid #dfdfdf; font-family:Arial, Helvetica, sans-serif; font-size:13px; color:#000; padding:7px 5px 7px 0;'>Mensaje:</td>
+	<td align='left' valign='top' style='border-top:1px solid #dfdfdf; border-bottom:1px solid #dfdfdf; font-family:Arial, Helvetica, sans-serif; font-size:13px; color:#000; padding:7px 0 7px 5px;'>".nl2br($mensaje)."</td>
+	</tr>
+	</table>
+	</body>
+	</html>
+	";
+	
+        $mail = new PHPMailer();
+        $mail->IsSMTP();
+        $mail->SMTPAuth = true;
+
+  if($smtpSecure!=""){
+    $mail->SMTPSecure = $smtpSecure;
+  }
+  $mail->Port = $smtpPort;
+  
+	$mail->IsHTML(true); 
+	$mail->CharSet = "utf-8";
+        $mail->Host = $smtpHost;
+        $mail->Username = $smtpUsuario;
+        $mail->Password = $smtpClave;
+        $mail->From = $fromEmail;
+        $mail->FromName = $fromName;
+        $mail->AddReplyTo($email, $nombre);
+        $mail->AddAddress("vende@miroperito.ar");
+	$mensaje = $message;
+	$mail->Subject = "Formulario de Contacto MiRoperito"; 
+	$mensajeHtml = nl2br($mensaje);
+	$mail->Body = "{$mensajeHtml} <br /><br />"; 
+	$mail->AltBody = "{$mensaje} \n\n"; 
+		
+	$mail->Send();
+
+	Database::disconnect();		
+	
+	header("Location: index.php");
+        exit;
+?>


### PR DESCRIPTION
## Summary
- add `contactar.php` at project root, reusing SMTP credentials from `admin/config.php`
- sanitize contact form fields and redirect to index after handling

## Testing
- `php -l contactar.php`
- `php -S 127.0.0.1:8000 >/tmp/phpserver.log 2>&1 &`
- `curl -i -X POST -d "nombre=Test&email=test@example.com&asunto=Hello&mensaje=Hola" http://127.0.0.1:8000/contactar.php`


------
https://chatgpt.com/codex/tasks/task_e_68c15c207b6c83219a836a0b24a8dd2c