### PR TITLE
Fix banner alt attribute

### DIFF
--- a/index.php
+++ b/index.php
@@ -31,7 +31,7 @@
 									sizes="1200w" 
 									srcset="images/Home/WEBP/banner-descuento1200px.webp 1200w" 
 									type="image/webp">
-								<img loading="lazy" decoding="async" src="images/Home/JPG/banner-descuento1200px.jpg" lazyalt="imagen" width="1200" height="300">
+								<img loading="lazy" decoding="async" src="images/Home/JPG/banner-descuento1200px.jpg" alt="imagen" width="1200" height="300">
 							</picture>
 						</div>
 					</div>


### PR DESCRIPTION
## Summary
- replace non-standard `lazyalt` attribute with standard `alt` on homepage banner image

## Testing
- `php -l index.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c15f48cdcc83219daf11c465e38b38