### PR TITLE
Eliminar referencias duplicadas a jQuery

### DIFF
--- a/scripts.php
+++ b/scripts.php
@@ -1,12 +1,10 @@
 <script src="js/img.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
-<script>window.jQuery || document.write('<script src="external/jquery/jquery.min.js"><\/script>')</script>
 <script defer src="js/bundle.js"></script>
 
 <script defer src="separate-include/single-product/single-product.js"></script>
 <script src="separate-include/portfolio/portfolio.js"></script>
 
-<script type="text/javascript" src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/owl-carousel/1.3.3/owl.carousel.min.js"></script>
 	
 <a href="#" class="tt-back-to-top">Volver al inicio</a>


### PR DESCRIPTION
## Summary
- Remove extra jQuery inclusion from `scripts.php` to use a single version
- Confirm plugin scripts rely on that jQuery instance

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1602cf8bc83219e92079ac7ad6f4e