### PR TITLE
fix database include path and disable convenio button when file missing

### DIFF
--- a/btn-convenio.php
+++ b/btn-convenio.php
@@ -1,19 +1,24 @@
 <section class="container btn-convenio">
 	<div>
-		<?php 
-		include 'admin/database.php';
-		$pdo = Database::connect();
-		$id = 9;
-  		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-		$sql = "SELECT id,parametro,valor FROM parametros WHERE id = ? ";
-		$q = $pdo->prepare($sql);
-		$q->execute([$id]);
-		$data = $q->fetch(PDO::FETCH_ASSOC);
+                <?php
+                require_once __DIR__ . '/admin/database.php';
+                $pdo = Database::connect();
+                $id = 9;
+                $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+                $sql = "SELECT id,parametro,valor FROM parametros WHERE id = ? ";
+                $q = $pdo->prepare($sql);
+                $q->execute([$id]);
+                $data = $q->fetch(PDO::FETCH_ASSOC);
 
-		Database::disconnect();
-		?>
-		<a href="admin/files/<?=$data["valor"];?>" target="_blank">Ver convenio</a>
-		<a href="turnos.php" class="segundo-enlace">Sacar turno para vender</a>
-		<a href="admin/loginProveedores.php" target="_blank">Ver el estado de mis ventas</a>
-	</div>
+                Database::disconnect();
+
+                $valor = $data['valor'] ?? '';
+                $fileUrl = 'admin/files/' . $valor;
+                $filePath = __DIR__ . '/' . $fileUrl;
+                $fileExists = $valor && file_exists($filePath);
+                ?>
+                <a href="<?= $fileExists ? $fileUrl : '#' ?>" <?= $fileExists ? 'target="_blank"' : 'class="disabled" title="Archivo no disponible" onclick="return false;"' ?>>Ver convenio</a>
+                <a href="turnos.php" class="segundo-enlace">Sacar turno para vender</a>
+                <a href="admin/loginProveedores.php" target="_blank">Ver el estado de mis ventas</a>
+        </div>
 </section>

--- a/testimonios.php
+++ b/testimonios.php
@@ -13,10 +13,10 @@
 				</div>
 				
 				<div class="col-sm-12 contenedor-carrusel">
-					<div id="testimonial-slider" class="owl-carousel carrusel"><?php
-						include 'admin/database.php';
-						$pdo = Database::connect();
-						$sql = "SELECT id, seccion,`url-jpg`, activo FROM banners WHERE activo = 1 AND seccion = 1"; 
+                                        <div id="testimonial-slider" class="owl-carousel carrusel"><?php
+                                                require_once __DIR__ . '/admin/database.php';
+                                                $pdo = Database::connect();
+                                                $sql = "SELECT id, seccion,`url-jpg`, activo FROM banners WHERE activo = 1 AND seccion = 1";
 
 						foreach ($pdo->query($sql) as $row) {
 							$nombreImagenJPG = $row['url-jpg'];
@@ -28,11 +28,11 @@
 							echo '</div>';
 						}
 
-						Database::disconnect();?>
-					</div>
-				</div>
-			</div>
-		</div>
-		<div class="col-1"></div>
-	</div>		
+                                               Database::disconnect();?>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+                <div class="col-1"></div>
+        </div>
 </section>


### PR DESCRIPTION
## Summary
- Use `require_once` with absolute path for database file
- Check for missing convenio file and disable button with warning title

## Testing
- `php -l btn-convenio.php`
- `php -l testimonios.php`
- `php btn-convenio.php | head -n 20` *(fails: no such table: parametros)*
- `php testimonios.php | head -n 20` *(fails: no such table: banners)*


------
https://chatgpt.com/codex/tasks/task_e_68c160c2f5508321b676ac7231217ca1