### PR TITLE
Use prepared statements for almacen lookup

### DIFF
--- a/emitirTurno.php
+++ b/emitirTurno.php
@@ -130,9 +130,9 @@ try {
   //var_dump($_POST);
   
 
-  $sqlZon = "SELECT almacen,direccion FROM almacenes WHERE id = ".$_POST['id_almacen'];
+  $sqlZon = "SELECT almacen,direccion FROM almacenes WHERE id = ?";
   $q = $pdo->prepare($sqlZon);
-  $q->execute();
+  $q->execute([$idAlmacen]);
   $fila = $q->fetch(PDO::FETCH_ASSOC);
   $almacen=$fila['almacen'];
   $direccion=$fila['direccion'];
@@ -243,9 +243,9 @@ try {
   //recordatorio_turno: Hola! Desde MiRoperito queremos recordarte acerca del turno que tenés reservado para hoy a las {{hora}}hs en {{direccion}}, {{almacen}}. Si no podés asistir a tu turno y deseas cancelarlo, responde CANCELAR. Muchas gracias!
 
   /*$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-  $sqlZon = "SELECT almacen,direccion FROM almacenes WHERE id = $sucursal";
+  $sqlZon = "SELECT almacen,direccion FROM almacenes WHERE id = ?";
   $q = $pdo->prepare($sqlZon);
-  $q->execute();
+  $q->execute([$sucursal]);
   $fila = $q->fetch(PDO::FETCH_ASSOC);
   $almacen=$fila['almacen'];*/
 

--- a/old_web/emitirTurno.php
+++ b/old_web/emitirTurno.php
@@ -130,9 +130,9 @@ try {
   //var_dump($_POST);
   
 
-  $sqlZon = "SELECT almacen,direccion FROM almacenes WHERE id = ".$_POST['id_almacen'];
+  $sqlZon = "SELECT almacen,direccion FROM almacenes WHERE id = ?";
   $q = $pdo->prepare($sqlZon);
-  $q->execute();
+  $q->execute([$idAlmacen]);
   $fila = $q->fetch(PDO::FETCH_ASSOC);
   $almacen=$fila['almacen'];
   $direccion=$fila['direccion'];
@@ -246,9 +246,9 @@ try {
   //recordatorio_turno: Hola! Desde MiRoperito queremos recordarte acerca del turno que tenés reservado para hoy a las {{hora}}hs en {{direccion}}, {{almacen}}. Si no podés asistir a tu turno y deseas cancelarlo, responde CANCELAR. Muchas gracias!
 
   /*$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-  $sqlZon = "SELECT almacen,direccion FROM almacenes WHERE id = $sucursal";
+  $sqlZon = "SELECT almacen,direccion FROM almacenes WHERE id = ?";
   $q = $pdo->prepare($sqlZon);
-  $q->execute();
+  $q->execute([$sucursal]);
   $fila = $q->fetch(PDO::FETCH_ASSOC);
   $almacen=$fila['almacen'];*/
 

--- a/old_web/probarEnvioMail.php
+++ b/old_web/probarEnvioMail.php
@@ -104,9 +104,9 @@
   //recordatorio_turno: Hola! Desde MiRoperito queremos recordarte acerca del turno que tenés reservado para hoy a las {{hora}}hs en {{direccion}}, {{almacen}}. Si no podés asistir a tu turno y deseas cancelarlo, responde CANCELAR. Muchas gracias!
 
   /*$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-  $sqlZon = "SELECT almacen,direccion FROM almacenes WHERE id = $sucursal";
+  $sqlZon = "SELECT almacen,direccion FROM almacenes WHERE id = ?";
   $q = $pdo->prepare($sqlZon);
-  $q->execute();
+  $q->execute([$sucursal]);
   $fila = $q->fetch(PDO::FETCH_ASSOC);
   $almacen=$fila['almacen'];*/
 


### PR DESCRIPTION
## Summary
- Replace string concatenation with prepared statements for almacen lookup queries
- Bind `$idAlmacen` as parameter and update legacy scripts accordingly

## Testing
- `php -l emitirTurno.php`
- `php -l old_web/emitirTurno.php`
- `php -l old_web/probarEnvioMail.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1632709888321bed8e13e92f58d49