### PR TITLE
Validate email before inserting into subscription list

### DIFF
--- a/js/suscribir.js
+++ b/js/suscribir.js
@@ -1,0 +1,24 @@
+$(function() {
+    $('#subscriptionForm').on('submit', function(e) {
+        e.preventDefault();
+        var $form = $(this);
+        $('#subscriptionLoader').show();
+        $.ajax({
+            url: $form.attr('action'),
+            type: 'POST',
+            data: $form.serialize(),
+            dataType: 'json'
+        }).done(function(resp) {
+            $('#subscriptionModalBody').text(resp.message);
+            $('#subscriptionModal').modal('show');
+            if (resp.status === 'success') {
+                $form[0].reset();
+            }
+        }).fail(function() {
+            $('#subscriptionModalBody').text('No se pudo procesar la solicitud.');
+            $('#subscriptionModal').modal('show');
+        }).always(function() {
+            $('#subscriptionLoader').hide();
+        });
+    });
+});

--- a/scripts.php
+++ b/scripts.php
@@ -1,6 +1,7 @@
 <script src="js/img.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script defer src="js/bundle.js"></script>
+<script defer src="js/suscribir.js"></script>
 
 <script defer src="separate-include/single-product/single-product.js"></script>
 <script src="separate-include/portfolio/portfolio.js"></script>

--- a/suscribir.php
+++ b/suscribir.php
@@ -1,21 +1,35 @@
 <?php
-require("admin/config.php");
-require("admin/database.php");
+require('admin/config.php');
+require('admin/database.php');
 
-$pdo = Database::connect();
-$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+header('Content-Type: application/json');
 
-$sql = "SELECT `id` from suscripciones where email = ?";
-$q = $pdo->prepare($sql);
-$q->execute(array($_POST['email']));
-$data = $q->fetch(PDO::FETCH_ASSOC);
-if (empty($data)) {
-    $sql = "INSERT INTO `suscripciones`(`email`, `fecha_hora`) VALUES (?,now())";
-    $q = $pdo->prepare($sql);
-    $q->execute(array($_POST['email']));
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['email'])) {
+    $email = trim($_POST['email']);
+    if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $pdo = Database::connect();
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-    Database::disconnect();
+        $sql = 'SELECT `id` from suscripciones where email = ?';
+        $q = $pdo->prepare($sql);
+        $q->execute([$email]);
+        $data = $q->fetch(PDO::FETCH_ASSOC);
+
+        if (empty($data)) {
+            $sql = 'INSERT INTO `suscripciones`(`email`, `fecha_hora`) VALUES (?,now())';
+            $q = $pdo->prepare($sql);
+            $q->execute([$email]);
+            Database::disconnect();
+            echo json_encode(['status' => 'success', 'message' => 'Suscripción realizada correctamente.']);
+        } else {
+            Database::disconnect();
+            echo json_encode(['status' => 'error', 'message' => 'El email ya está suscripto.']);
+        }
+    } else {
+        echo json_encode(['status' => 'error', 'message' => 'Email inválido.']);
+    }
+    exit;
 }
-header("Location: index.php");
-?>
 
+echo json_encode(['status' => 'error', 'message' => 'Solicitud inválida.']);
+?>

--- a/suscribite.php
+++ b/suscribite.php
@@ -1,20 +1,40 @@
 <section>
-				<div class="container-indent">
-					<div class="container contenedor-subscribite">
-						<div class="row justify-content-center">
-							<div class="col-md-10 col-lg-8 col-xl-8">
-								<div class="tt-layout-newsletter02">
-									<h3 class="tt-title subscribite">ENTERATE DE LAS ÚLTIMAS NOVEDADES</h3>
-									
-									<form id="" class="form-inline form-default form-subscribite" method="post" action="suscribir.php">
-										<div class="form-group">
-											<input type="email" name="email" class="form-control form-subscribite-input" placeholder="Ingresá tu email" required="required" style="">
-											<button type="submit" class="btn btn-lg">Suscribite!</button>
-										</div>
-									</form>
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
-			</section>
+                                <div class="container-indent">
+                                        <div class="container contenedor-subscribite">
+                                                <div class="row justify-content-center">
+                                                        <div class="col-md-10 col-lg-8 col-xl-8">
+                                                                <div class="tt-layout-newsletter02">
+                                                                        <h3 class="tt-title subscribite">ENTERATE DE LAS ÚLTIMAS NOVEDADES</h3>
+
+                                                                        <form id="subscriptionForm" class="form-inline form-default form-subscribite" method="post" action="suscribir.php">
+                                                                                <div class="form-group">
+                                                                                        <input type="email" name="email" class="form-control form-subscribite-input" placeholder="Ingresá tu email" required="required" style="">
+                                                                                        <button type="submit" class="btn btn-lg">Suscribite!</button>
+                                                                                </div>
+                                                                        </form>
+                                                                        <div id="subscriptionLoader" class="spinner-border text-primary" role="status" style="display:none;">
+                                                                                <span class="sr-only">Procesando...</span>
+                                                                        </div>
+                                                                </div>
+                                                        </div>
+                                                </div>
+                                        </div>
+                                </div>
+
+                                <div class="modal fade" id="subscriptionModal" tabindex="-1" role="dialog" aria-hidden="true">
+                                        <div class="modal-dialog" role="document">
+                                                <div class="modal-content">
+                                                        <div class="modal-header">
+                                                                <h5 class="modal-title">Suscripción</h5>
+                                                                <button type="button" class="close" data-dismiss="modal" aria-label="Cerrar">
+                                                                        <span aria-hidden="true">&times;</span>
+                                                                </button>
+                                                        </div>
+                                                        <div class="modal-body" id="subscriptionModalBody"></div>
+                                                        <div class="modal-footer">
+                                                                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+                                                        </div>
+                                                </div>
+                                        </div>
+                                </div>
+                        </section>


### PR DESCRIPTION
## Summary
- Verify POST requests provide an email before processing subscriptions
- Use AJAX with loader and modal feedback instead of GET redirects
- Include new script for asynchronous subscription handling

## Testing
- `php -l suscribir.php`
- `php -l suscribite.php`
- `php -l scripts.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c162ff33d88321b47271a098d6fa24