### PR TITLE
Add reCAPTCHA validation to contact form

### DIFF
--- a/admin/config.php
+++ b/admin/config.php
@@ -7,4 +7,8 @@ $smtpUsuario = getenv('SMTP_USER') ?: 'avisos@miroperito.ar';
 $smtpClave = getenv('SMTP_PASS') ?: '';
 $fromEmail = getenv('SMTP_FROM') ?: 'avisos@miroperito.ar';
 $fromName  = getenv('SMTP_FROM_NAME') ?: 'MiRoperito';
+
+// reCAPTCHA keys for client (site) and server (secret)
+$recaptchaSiteKey   = getenv('RECAPTCHA_SITE_KEY') ?: '';
+$recaptchaSecretKey = getenv('RECAPTCHA_SECRET_KEY') ?: '';
 ?>

--- a/contactar.php
+++ b/contactar.php
@@ -17,6 +17,21 @@
         exit;
     }
 
+    $recaptchaResponse = $_POST['g-recaptcha-response'] ?? '';
+    $recaptchaValid = false;
+    if ($recaptchaResponse && !empty($recaptchaSecretKey)) {
+        $verifyResponse = file_get_contents(
+            'https://www.google.com/recaptcha/api/siteverify?secret=' .
+            urlencode($recaptchaSecretKey) . '&response=' . urlencode($recaptchaResponse)
+        );
+        $responseData = json_decode($verifyResponse, true);
+        $recaptchaValid = $responseData['success'] ?? false;
+    }
+    if (!$recaptchaValid) {
+        echo 'Error: reCAPTCHA inválido.';
+        exit;
+    }
+
     $pdo = Database::connect();
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     $sql = "INSERT INTO `contactos`(`fecha_hora`, `nombre`, `email`, `asunto`, `mensaje`) VALUES (now(),?,?,?,?)";

--- a/contacto.php
+++ b/contacto.php
@@ -1,7 +1,9 @@
+<?php require_once __DIR__ . "/admin/config.php"; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<?php include("head.php"); ?>
+        <?php include("head.php"); ?>
+        <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 </head>
 <body>
   <div id="loader-wrapper">
@@ -56,6 +58,7 @@
                 <label for="form-text">Mensaje</label>
               </div>
 
+              <div class="g-recaptcha" data-sitekey="<?php echo $recaptchaSiteKey; ?>"></div>
               <div class="text-center">
                 <button type="submit" class="btn btn-light-blue">Envíar</button>
               </div>


### PR DESCRIPTION
## Summary
- Expose reCAPTCHA site and secret keys in admin config for easier maintenance
- Embed Google reCAPTCHA widget and script on the contact page
- Verify reCAPTCHA token server-side in contactar.php, halting on failure

## Testing
- `php -l admin/config.php`
- `php -l contacto.php`
- `php -l contactar.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c16d4a5c5883219ac6f7d7971a61bc