### PR TITLE
Add reCAPTCHA validation and IP rate limiting to subscription

### DIFF
--- a/admin/config.php
+++ b/admin/config.php
@@ -7,4 +7,9 @@ $smtpUsuario = getenv('SMTP_USER') ?: 'avisos@miroperito.ar';
 $smtpClave = getenv('SMTP_PASS') ?: '';
 $fromEmail = getenv('SMTP_FROM') ?: 'avisos@miroperito.ar';
 $fromName  = getenv('SMTP_FROM_NAME') ?: 'MiRoperito';
+
+// Google reCAPTCHA keys
+// Using Google's test keys by default; override via environment variables.
+$recaptchaSite   = getenv('RECAPTCHA_SITE') ?: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
+$recaptchaSecret = getenv('RECAPTCHA_SECRET') ?: '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe';
 ?>

--- a/suscribir.php
+++ b/suscribir.php
@@ -4,19 +4,58 @@ require('admin/database.php');
 
 header('Content-Type: application/json');
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['email'])) {
+if (
+    $_SERVER['REQUEST_METHOD'] === 'POST' &&
+    isset($_POST['email'], $_POST['g-recaptcha-response'])
+) {
+    $ip = $_SERVER['REMOTE_ADDR'] ?? '';
+    $recaptchaToken = $_POST['g-recaptcha-response'];
+    $recaptchaUrl = 'https://www.google.com/recaptcha/api/siteverify';
+    $recaptchaResp = file_get_contents(
+        $recaptchaUrl . '?secret=' . urlencode($recaptchaSecret) .
+        '&response=' . urlencode($recaptchaToken) .
+        '&remoteip=' . urlencode($ip)
+    );
+    $recaptchaData = json_decode($recaptchaResp, true);
+    if (empty($recaptchaData['success'])) {
+        echo json_encode(['status' => 'error', 'message' => 'reCAPTCHA inválido.']);
+        exit;
+    }
+
+    $pdo = Database::connect();
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    // Log IP and limit frequency
+    $pdo->exec(
+        'CREATE TABLE IF NOT EXISTS suscripciones_log (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            ip VARCHAR(45) NOT NULL,
+            fecha_hora DATETIME NOT NULL
+        )'
+    );
+
+    $log = $pdo->prepare('INSERT INTO suscripciones_log (ip, fecha_hora) VALUES (?, NOW())');
+    $log->execute([$ip]);
+
+    $attemptsStmt = $pdo->prepare(
+        'SELECT COUNT(*) FROM suscripciones_log WHERE ip = ? AND fecha_hora >= (NOW() - INTERVAL 1 HOUR)'
+    );
+    $attemptsStmt->execute([$ip]);
+    if ($attemptsStmt->fetchColumn() > 5) {
+        Database::disconnect();
+        echo json_encode(['status' => 'error', 'message' => 'Demasiadas solicitudes desde esta IP. Intente más tarde.']);
+        exit;
+    }
+
     $email = trim($_POST['email']);
     if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
-        $pdo = Database::connect();
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-
-        $sql = 'SELECT `id` from suscripciones where email = ?';
+        $sql = 'SELECT `id` FROM suscripciones WHERE email = ?';
         $q = $pdo->prepare($sql);
         $q->execute([$email]);
         $data = $q->fetch(PDO::FETCH_ASSOC);
 
         if (empty($data)) {
-            $sql = 'INSERT INTO `suscripciones`(`email`, `fecha_hora`) VALUES (?,now())';
+            $sql = 'INSERT INTO `suscripciones`(`email`, `fecha_hora`) VALUES (?, NOW())';
             $q = $pdo->prepare($sql);
             $q->execute([$email]);
             Database::disconnect();
@@ -26,6 +65,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['email'])) {
             echo json_encode(['status' => 'error', 'message' => 'El email ya está suscripto.']);
         }
     } else {
+        Database::disconnect();
         echo json_encode(['status' => 'error', 'message' => 'Email inválido.']);
     }
     exit;

--- a/suscribite.php
+++ b/suscribite.php
@@ -1,3 +1,5 @@
+<?php require('admin/config.php'); ?>
+<script src="https://www.google.com/recaptcha/api.js" async defer></script>
 <section>
                                 <div class="container-indent">
                                         <div class="container contenedor-subscribite">
@@ -9,6 +11,7 @@
                                                                         <form id="subscriptionForm" class="form-inline form-default form-subscribite" method="post" action="suscribir.php">
                                                                                 <div class="form-group">
                                                                                         <input type="email" name="email" class="form-control form-subscribite-input" placeholder="Ingresá tu email" required="required" style="">
+                                                                                        <div class="g-recaptcha" data-sitekey="<?php echo $recaptchaSite; ?>"></div>
                                                                                         <button type="submit" class="btn btn-lg">Suscribite!</button>
                                                                                 </div>
                                                                         </form>


### PR DESCRIPTION
## Summary
- add Google reCAPTCHA keys to config
- embed reCAPTCHA widget in subscription form
- verify reCAPTCHA and rate limit subscriptions by IP

## Testing
- `php -l admin/config.php`
- `php -l suscribite.php`
- `php -l suscribir.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c16d7ad49483219ec5c0e751f6da63