### PR TITLE
Use recaptchaSecretKey variable in scripts

### DIFF
--- a/emitirTurno.php
+++ b/emitirTurno.php
@@ -134,7 +134,7 @@ if (rateLimited($ip)) {
     jsonResponse(false, 'Demasiadas solicitudes desde esta IP. Intente nuevamente más tarde.');
 }
 
-if (!verifyRecaptcha($recaptchaToken, $recaptchaSecret, $ip)) {
+if (!verifyRecaptcha($recaptchaToken, $recaptchaSecretKey, $ip)) {
     Database::disconnect();
     jsonResponse(false, 'Verificación de reCAPTCHA fallida.');
 }

--- a/suscribir.php
+++ b/suscribir.php
@@ -12,7 +12,7 @@ if (
     $recaptchaToken = $_POST['g-recaptcha-response'];
     $recaptchaUrl = 'https://www.google.com/recaptcha/api/siteverify';
     $recaptchaResp = file_get_contents(
-        $recaptchaUrl . '?secret=' . urlencode($recaptchaSecret) .
+        $recaptchaUrl . '?secret=' . urlencode($recaptchaSecretKey) .
         '&response=' . urlencode($recaptchaToken) .
         '&remoteip=' . urlencode($ip)
     );


### PR DESCRIPTION
## Summary
- Replace `$recaptchaSecret` with `$recaptchaSecretKey` in `suscribir.php` and `emitirTurno.php`
- Confirm both scripts continue requiring `admin/config.php`

## Testing
- `php -l suscribir.php`
- `php -l emitirTurno.php`


------
https://chatgpt.com/codex/tasks/task_e_68c172055a18832185fe85cd9d46cb33