### PR TITLE
Load reCAPTCHA keys from environment and document deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ admin/BAK
 nueva_web/images/Banners
 save_log.txt
 miroperitodb.sql
+.env

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,29 @@
+# Deployment
+
+The application requires Google reCAPTCHA credentials.
+
+## Configure reCAPTCHA keys
+
+Set the following environment variables on the production server or provide them in a `.env` file located at the project root:
+
+- `RECAPTCHA_SITE_KEY` – public site key used by the client.
+- `RECAPTCHA_SECRET_KEY` – secret key used for server-side verification.
+
+### Using environment variables
+
+```bash
+export RECAPTCHA_SITE_KEY="<your site key>"
+export RECAPTCHA_SECRET_KEY="<your secret key>"
+```
+Ensure these are loaded for the web server process (e.g. via the service configuration).
+
+### Using a `.env` file
+
+Create a file named `.env` with the keys:
+
+```env
+RECAPTCHA_SITE_KEY=<your site key>
+RECAPTCHA_SECRET_KEY=<your secret key>
+```
+
+The `.env` file is ignored by Git and should never be committed. Keep it secure.

--- a/admin/config.php
+++ b/admin/config.php
@@ -9,7 +9,16 @@ $fromEmail = getenv('SMTP_FROM') ?: 'avisos@miroperito.ar';
 $fromName  = getenv('SMTP_FROM_NAME') ?: 'MiRoperito';
 
 // reCAPTCHA keys for client (site) and server (secret)
-$recaptchaSiteKey   = getenv('RECAPTCHA_SITE_KEY') ?: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
-$recaptchaSecretKey = getenv('RECAPTCHA_SECRET_KEY') ?: '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe';
+$recaptchaSiteKey   = getenv('RECAPTCHA_SITE_KEY');
+$recaptchaSecretKey = getenv('RECAPTCHA_SECRET_KEY');
+
+if (!$recaptchaSiteKey || !$recaptchaSecretKey) {
+    $envPath = dirname(__DIR__) . '/.env';
+    if (file_exists($envPath)) {
+        $env = parse_ini_file($envPath);
+        $recaptchaSiteKey   = $recaptchaSiteKey   ?: ($env['RECAPTCHA_SITE_KEY'] ?? null);
+        $recaptchaSecretKey = $recaptchaSecretKey ?: ($env['RECAPTCHA_SECRET_KEY'] ?? null);
+    }
+}
 
 ?>


### PR DESCRIPTION
## Summary
- remove hardcoded reCAPTCHA test keys
- load keys from environment variables or a `.env` file
- document how to configure these keys during deployment

## Testing
- `php -l admin/config.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c172371dbc83218f2954a53cc65b93