### PR TITLE
Support development reCAPTCHA keys via APP_ENV

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -27,3 +27,28 @@ RECAPTCHA_SECRET_KEY=<your secret key>
 ```
 
 The `.env` file is ignored by Git and should never be committed. Keep it secure.
+
+## Local development
+
+To test reCAPTCHA locally, set `APP_ENV=development` and provide development keys:
+
+- `RECAPTCHA_SITE_KEY_DEV` – site key for local testing.
+- `RECAPTCHA_SECRET_KEY_DEV` – secret key for local testing.
+
+These can be supplied as environment variables:
+
+```bash
+export APP_ENV=development
+export RECAPTCHA_SITE_KEY_DEV="<your dev site key>"
+export RECAPTCHA_SECRET_KEY_DEV="<your dev secret key>"
+```
+
+Or through additional entries in `.env`:
+
+```env
+APP_ENV=development
+RECAPTCHA_SITE_KEY_DEV=<your dev site key>
+RECAPTCHA_SECRET_KEY_DEV=<your dev secret key>
+```
+
+When `APP_ENV` is set to `development`, the application will automatically use the development keys; otherwise the production keys are used.

--- a/admin/config.php
+++ b/admin/config.php
@@ -8,17 +8,21 @@ $smtpClave = getenv('SMTP_PASS') ?: '';
 $fromEmail = getenv('SMTP_FROM') ?: 'avisos@miroperito.ar';
 $fromName  = getenv('SMTP_FROM_NAME') ?: 'MiRoperito';
 
-// reCAPTCHA keys for client (site) and server (secret)
-$recaptchaSiteKey   = getenv('RECAPTCHA_SITE_KEY');
-$recaptchaSecretKey = getenv('RECAPTCHA_SECRET_KEY');
+$envPath = dirname(__DIR__) . '/.env';
+$env = file_exists($envPath) ? parse_ini_file($envPath) : [];
 
-if (!$recaptchaSiteKey || !$recaptchaSecretKey) {
-    $envPath = dirname(__DIR__) . '/.env';
-    if (file_exists($envPath)) {
-        $env = parse_ini_file($envPath);
-        $recaptchaSiteKey   = $recaptchaSiteKey   ?: ($env['RECAPTCHA_SITE_KEY'] ?? null);
-        $recaptchaSecretKey = $recaptchaSecretKey ?: ($env['RECAPTCHA_SECRET_KEY'] ?? null);
-    }
+// Environment selection
+$appEnv = getenv('APP_ENV') ?: ($env['APP_ENV'] ?? null);
+
+// reCAPTCHA keys for client (site) and server (secret)
+$recaptchaSiteKey     = getenv('RECAPTCHA_SITE_KEY')     ?: ($env['RECAPTCHA_SITE_KEY']     ?? null);
+$recaptchaSecretKey   = getenv('RECAPTCHA_SECRET_KEY')   ?: ($env['RECAPTCHA_SECRET_KEY']   ?? null);
+$recaptchaSiteKeyDev  = getenv('RECAPTCHA_SITE_KEY_DEV') ?: ($env['RECAPTCHA_SITE_KEY_DEV'] ?? null);
+$recaptchaSecretKeyDev= getenv('RECAPTCHA_SECRET_KEY_DEV') ?: ($env['RECAPTCHA_SECRET_KEY_DEV'] ?? null);
+
+if ($appEnv === 'development') {
+    $recaptchaSiteKey   = $recaptchaSiteKeyDev   ?: $recaptchaSiteKey;
+    $recaptchaSecretKey = $recaptchaSecretKeyDev ?: $recaptchaSecretKey;
 }
 
 ?>


### PR DESCRIPTION
## Summary
- Load reCAPTCHA dev keys when `APP_ENV` is set to development
- Document how to configure dev environment variables

## Testing
- `php -l admin/config.php`
- `php -l suscribite.php contacto.php turnos.php`


------
https://chatgpt.com/codex/tasks/task_e_68c17bd814e483218d02a9999a895bfc