### PR TITLE
Handle contact form submission with AJAX and JSON responses

### DIFF
--- a/contactar.php
+++ b/contactar.php
@@ -5,6 +5,8 @@
     require_once __DIR__ . "/admin/PHPMailer/class.phpmailer.php";
     require_once __DIR__ . "/admin/PHPMailer/class.smtp.php";
 
+    header('Content-Type: application/json');
+
     $nombre  = trim($_POST["nombre"] ?? '');
     $email   = trim($_POST["email"] ?? '');
     $mensaje = trim($_POST["mensaje"] ?? '');
@@ -13,7 +15,7 @@
     if (!filter_var($email, FILTER_VALIDATE_EMAIL) ||
         strlen($nombre) > 100 || strlen($subject) > 150 || strlen($mensaje) > 1000 ||
         $nombre !== strip_tags($nombre) || $subject !== strip_tags($subject) || $mensaje !== strip_tags($mensaje)) {
-        header("Location: index.php");
+        echo json_encode(['success' => false, 'message' => 'Datos inválidos.']);
         exit;
     }
 
@@ -28,7 +30,7 @@
         $recaptchaValid = $responseData['success'] ?? false;
     }
     if (!$recaptchaValid) {
-        echo 'Error: reCAPTCHA inválido.';
+        echo json_encode(['success' => false, 'message' => 'Error: reCAPTCHA inválido.']);
         exit;
     }
 
@@ -99,8 +101,8 @@
 		
 	$mail->Send();
 
-	Database::disconnect();		
-	
-	header("Location: index.php");
+        Database::disconnect();
+
+        echo json_encode(['success' => true, 'message' => 'Mensaje enviado correctamente.']);
         exit;
 ?>

--- a/contacto.php
+++ b/contacto.php
@@ -37,7 +37,7 @@
             <div class="form-header blue accent-1">
               <h3 class="mt-2"><i class="fas fa-envelope"></i> Escribinos!</h3>
             </div>
-            <form id="" class="" method="post" action="contactar.php">			
+            <form id="contactForm" class="" method="post" action="contactar.php">
               <!-- Body -->
               <div class="md-form">
                 <label for="form-name">Nombre</label>
@@ -121,6 +121,18 @@
         </div>
       </div><!-- Grid column -->
     </div><!-- Grid row -->
+    <div class="modal" id="contact-message" tabindex="-1" role="dialog">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-body">
+            <p id="contact-message-text" class="mb-0"></p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">OK</button>
+          </div>
+        </div>
+      </div>
+    </div>
   </section><!-- Section: Contact v.1 -->
 
 	<?php include("testimonios.php"); ?>
@@ -132,5 +144,6 @@
   </footer>
 
   <?php include("scripts.php"); ?>
+  <script defer src="js/contacto.js"></script>
 </body>
 </html>

--- a/js/contacto.js
+++ b/js/contacto.js
@@ -1,0 +1,28 @@
+$(function() {
+    $('#contactForm').on('submit', function(e) {
+        e.preventDefault();
+        var $form = $(this);
+        var recaptchaResponse = grecaptcha.getResponse();
+        if (!recaptchaResponse) {
+            $('#contact-message-text').text('Por favor, verifica el reCAPTCHA.');
+            $('#contact-message').modal('show');
+            return;
+        }
+        $.ajax({
+            url: $form.attr('action'),
+            type: 'POST',
+            data: $form.serialize(),
+            dataType: 'json'
+        }).done(function(resp) {
+            $('#contact-message-text').text(resp.message);
+            $('#contact-message').modal('show');
+            if (resp.success) {
+                $form[0].reset();
+                grecaptcha.reset();
+            }
+        }).fail(function() {
+            $('#contact-message-text').text('No se pudo enviar el mensaje.');
+            $('#contact-message').modal('show');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add `contactForm` id and feedback modal to the contact page.
- Send contact requests via AJAX with client-side reCAPTCHA check and modal messaging.
- Return JSON responses from `contactar.php` while preserving server-side reCAPTCHA validation.

## Testing
- `php -l contacto.php`
- `php -l contactar.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1813ab02083218f78f1779f490194