### PR TITLE
Validate reCAPTCHA before subscription AJAX

### DIFF
--- a/js/suscribir.js
+++ b/js/suscribir.js
@@ -2,6 +2,12 @@ $(function() {
     $('#subscriptionForm').on('submit', function(e) {
         e.preventDefault();
         var $form = $(this);
+        if (typeof grecaptcha !== 'undefined' && !grecaptcha.getResponse()) {
+            $('#subscriptionModalBody').text('Por favor, completá el reCAPTCHA.');
+            $('#subscriptionModal').modal('show');
+            return;
+        }
+
         $('#subscriptionLoader').show();
         $.ajax({
             url: $form.attr('action'),
@@ -13,6 +19,9 @@ $(function() {
             $('#subscriptionModal').modal('show');
             if (resp.status === 'success') {
                 $form[0].reset();
+                if (typeof grecaptcha !== 'undefined') {
+                    grecaptcha.reset();
+                }
             }
         }).fail(function() {
             $('#subscriptionModalBody').text('No se pudo procesar la solicitud.');


### PR DESCRIPTION
## Summary
- Check reCAPTCHA response before sending subscription AJAX request
- Reset reCAPTCHA when the subscription succeeds

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c181531ebc83219893cf6a31e1a58d