### PR TITLE
Disable contact submit button while sending

### DIFF
--- a/js/contacto.js
+++ b/js/contacto.js
@@ -2,12 +2,15 @@ $(function() {
     $('#contactForm').on('submit', function(e) {
         e.preventDefault();
         var $form = $(this);
+        var $submitBtn = $form.find('button[type="submit"]');
+        var originalText = $submitBtn.text();
         var recaptchaResponse = grecaptcha.getResponse();
         if (!recaptchaResponse) {
             $('#contact-message-text').text('Por favor, verifica el reCAPTCHA.');
             $('#contact-message').modal('show');
             return;
         }
+        $submitBtn.prop('disabled', true).text('Enviando...');
         $.ajax({
             url: $form.attr('action'),
             type: 'POST',
@@ -16,6 +19,7 @@ $(function() {
         }).done(function(resp) {
             $('#contact-message-text').text(resp.message);
             $('#contact-message').modal('show');
+            $submitBtn.prop('disabled', false).text(originalText);
             if (resp.success) {
                 $form[0].reset();
                 grecaptcha.reset();
@@ -23,6 +27,7 @@ $(function() {
         }).fail(function() {
             $('#contact-message-text').text('No se pudo enviar el mensaje.');
             $('#contact-message').modal('show');
+            $submitBtn.prop('disabled', false).text(originalText);
         });
     });
 });


### PR DESCRIPTION
## Summary
- Disable and change contact form submit button to 'Enviando...' after reCAPTCHA validation
- Restore button text and state after AJAX success or failure while keeping server response modal

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ba9336648321b1a4cd57c6db823a